### PR TITLE
[trunk] Adapt to LTAC becoming a plugin.

### DIFF
--- a/src/Common/Tactics/hint_db_extra_plugin.ml4.trunk
+++ b/src/Common/Tactics/hint_db_extra_plugin.ml4.trunk
@@ -1,5 +1,6 @@
 open Hint_db_extra_tactics
 open Stdarg
+open Ltac_plugin
 open Tacarg
 
 DECLARE PLUGIN "hint_db_extra_plugin"

--- a/src/Common/Tactics/hint_db_extra_tactics.ml.trunk
+++ b/src/Common/Tactics/hint_db_extra_tactics.ml.trunk
@@ -2,6 +2,7 @@ module WITH_DB =
   struct
     open Tacticals.New
     open Names
+    open Ltac_plugin
 
   (* [tac] : string representing identifier *)
   (* [args] : tactic arguments *)

--- a/src/Common/Tactics/transparent_abstract_plugin.ml4.trunk
+++ b/src/Common/Tactics/transparent_abstract_plugin.ml4.trunk
@@ -1,5 +1,6 @@
 open Transparent_abstract_tactics
 open Stdarg
+open Ltac_plugin
 open Tacarg
 
     (*

--- a/src/Common/Tactics/transparent_abstract_tactics.ml.trunk
+++ b/src/Common/Tactics/transparent_abstract_tactics.ml.trunk
@@ -10,6 +10,7 @@ module TRANSPARENT_ABSTRACT =
     open Names
     open Nameops
     open Tacticals.New
+    open Ltac_plugin
     open Tacmach.New
     open Proofview.Notations
     open Safe_typing


### PR DESCRIPTION
This makes the parsers target of fiat to build with Coq trunk. Once merge I'll add fiat-parsers to Coq's Travis CI.