### PR TITLE
Fix compilation with trunk

### DIFF
--- a/src/Common/Tactics/transparent_abstract_tactics.ml.trunk
+++ b/src/Common/Tactics/transparent_abstract_tactics.ml.trunk
@@ -17,13 +17,27 @@ module TRANSPARENT_ABSTRACT =
     open Proof_global
     open Sigma.Notations
     (* Copied from tactics.ml *)
-    let interpretable_as_section_decl evd d1 d2 =
+    let interpretable_as_section_decl evdref d1 d2 =
       let open Context.Named.Declaration in
       match d2, d1 with
       | LocalDef _, LocalAssum _ -> false
       | LocalDef (_,b1,t1), LocalDef (_,b2,t2) ->
-        Evd.e_eq_constr_univs evd b1 b2 && Evd.e_eq_constr_univs evd t1 t2
-      | LocalAssum (_,t1), d2 -> Evd.e_eq_constr_univs evd t1 (get_type d2)
+        begin match EConstr.eq_constr_universes !evdref b1 b2 with
+        | None -> false
+        | Some cstr ->
+          let () = evdref := Evd.add_universe_constraints !evdref cstr in
+          match EConstr.eq_constr_universes !evdref t1 t2 with
+          | None -> false
+          | Some cstr ->
+            let () = evdref := Evd.add_universe_constraints !evdref cstr in
+            true
+        end
+      | LocalAssum (_,t1), d2 ->
+        match EConstr.eq_constr_universes !evdref t1 (get_type d2) with
+        | None -> false
+        | Some cstr ->
+          let () = evdref := Evd.add_universe_constraints !evdref cstr in
+          true
 
     (* [tac] : string representing identifier *)
     (* [args] : tactic arguments *)
@@ -52,7 +66,7 @@ module TRANSPARENT_ABSTRACT =
     (* Build a new definition for [term] with identifier [id] and call *)
     (* the [tacK] tactic with the result, using [lcl] to decide if the *)
     (* definition is local. *)
-    let transparent_abstract_term id (term : Term.constr) tacK gk lcl =
+    let transparent_abstract_term id (term : EConstr.constr) tacK gk lcl =
       let open Tacticals.New in
       let open Tacmach.New in
       let open Proofview.Notations in
@@ -71,8 +85,8 @@ module TRANSPARENT_ABSTRACT =
               (fun d (s1,s2) ->
                let id = get_id d in
                if mem_named_context_val id current_sign &&
-                    interpretable_as_section_decl evdref (lookup_named_val id current_sign) d
-               then (s1,push_named_context_val d s2)
+                    interpretable_as_section_decl evdref (EConstr.lookup_named_val id current_sign) d
+               then (s1,EConstr.push_named_context_val d s2)
                else (Context.Named.add d s1,s2))
               global_sign (Context.Named.empty,empty_named_context_val) in
           (* Build the identifier for the new term *)
@@ -119,19 +133,15 @@ module TRANSPARENT_ABSTRACT =
           (** bendy: Seems okay for new constant to be local, but may have unintended **)
           (** consequences if abstracted terms should be accessed outside the proof. **)
           let cst = Declare.declare_constant ~internal:Declare.InternalTacticRequest ~local:lcl id decl in
-          let df, ctx = Universes.unsafe_constr_of_global (Globnames.ConstRef cst) in
-          (* Get the universe context associated with the evar map [evd] *)
-          let ectx = Evd.evar_universe_context evd in
-          (* Universe Variable stuff? *)
-          let evd = Evd.set_universe_context evd ectx in
+          pf_constr_of_global (Globnames.ConstRef cst) begin fun df ->
           (* Build a private constant for the new constant *)
           let eff = private_con_of_con (Global.safe_env ()) cst in
           (* Add that constant to the private constants *)
           let effs = add_private eff
                                  Entries.(snd (Future.force constr.const_entry_body)) in
-          Proofview.Unsafe.tclEVARS evd <*>
             Proofview.tclEFFECTS effs <*>
             ltac_apply tacK (Tacinterp.Value.of_constr df)
+          end
         end }
 
     (* Solve the goal [gk] by tactic [tak] and save the constructed term as *)
@@ -156,8 +166,8 @@ module TRANSPARENT_ABSTRACT =
               (fun d (s1,s2) ->
                let id = get_id d in
                if mem_named_context_val id current_sign &&
-                    interpretable_as_section_decl evdref (lookup_named_val id current_sign) d
-               then (s1,push_named_context_val d s2)
+                    interpretable_as_section_decl evdref (EConstr.lookup_named_val id current_sign) d
+               then (s1,EConstr.push_named_context_val d s2)
                else (Context.Named.add d s1,s2))
               global_sign (Context.Named.empty,empty_named_context_val) in
           (* Build the identifier for the new term *)
@@ -175,7 +185,7 @@ module TRANSPARENT_ABSTRACT =
             (* FIXME: should be done only if the tactic succeeds *)
             let evd, nf = nf_evars_and_universes !evdref in
             let ctx = Evd.universe_context_set evd in
-            evd, ctx, nf concl
+            evd, ctx, EConstr.of_constr (nf concl)
           in
           (* This is the tactic script that should solve the goal. *)
           let solve_tac = tclCOMPLETE (tclTHEN (tclDO (List.length sign) Tactics.intro) tac) in
@@ -199,7 +209,7 @@ module TRANSPARENT_ABSTRACT =
           (** consequences if abstracted terms should be accessed outside the proof. **)
           let cst = Declare.declare_constant ~internal:Declare.InternalTacticRequest ~local:lcl id decl in
           (* Tactic Monad *)
-          let df, ctx = Universes.unsafe_constr_of_global (Globnames.ConstRef cst) in
+          pf_constr_of_global (Globnames.ConstRef cst) begin fun df ->
           (* Universe Variable stuff? *)
           let evd = Evd.set_universe_context evd ectx in
           (* Build a private constant for the new constant *)
@@ -208,14 +218,15 @@ module TRANSPARENT_ABSTRACT =
           let effs = add_private eff
                                  Entries.(snd (Future.force const.const_entry_body)) in
           (* Get the local arguments to apply the new constant to. *)
-          let args = List.rev (Context.Named.to_instance sign) in
+          let args = List.rev (Context.Named.to_instance EConstr.mkVar sign) in
           (* Use the definition built above to solve the goal. *)
           let solve =
             Proofview.Unsafe.tclEVARS evd <*>
               Proofview.tclEFFECTS effs <*>
-              Tactics.exact_no_check (Term.applist (df, args))
+              Tactics.exact_no_check (EConstr.applist (df, args))
           in
           if not safe then Proofview.mark_as_unsafe <*> solve else solve
+          end
         end }
 
     (* Default identifier *)

--- a/src/Common/ilist.v
+++ b/src/Common/ilist.v
@@ -200,7 +200,7 @@ Section ilist_imap.
     : ilist As -> ilist As :=
     match As return ilist As -> ilist As with
     | [] => fun il => inil
-    | a :: As' => fun il => icons (f (ilist_hd il)) (imap As' (ilist_tl il))
+    | a :: As' => fun il => icons (@f a (ilist_hd il)) (imap As' (ilist_tl il))
     end.
 
   (* [imap] behaves as expected with the [ith_default] lookup
@@ -244,7 +244,7 @@ Section ilist_replace.
     : ilist As :=
     match n in Fin.t m return
           forall (As : Vector.t A m),
-            ilist As
+            @ilist _ B _ As
             -> B (Vector.nth As n)
             -> ilist As with
     | Fin.F1 k =>

--- a/src/Common/ilist2.v
+++ b/src/Common/ilist2.v
@@ -191,7 +191,7 @@ Section ilist2_imap.
     : ilist2 As -> ilist2 As :=
     match As return ilist2 As -> ilist2 As with
     | [] => fun il => inil2
-    | a :: As' => fun il => icons2 (f (ilist2_hd il)) (imap2 As' (ilist2_tl il))
+    | a :: As' => fun il => icons2 (@f a (ilist2_hd il)) (imap2 As' (ilist2_tl il))
     end.
 
   (* [imap] behaves as expected with the [ith2_default] lookup
@@ -235,7 +235,7 @@ Section ilist2_replace.
     : ilist2 As :=
     match n in Fin.t m return
           forall (As : Vector.t A m),
-            ilist2 As
+            @ilist2 _ B _ As
             -> B (Vector.nth As n)
             -> ilist2 As with
     | Fin.F1 k =>
@@ -359,7 +359,7 @@ Section ilist2_update.
     : ilist2 As :=
     match n in Fin.t m return
           forall (As : Vector.t A m),
-            ilist2 As
+            @ilist2 _ B _ As
             -> (B (Vector.nth As n) -> B (Vector.nth As n))
             -> ilist2 As with
     | Fin.F1 k =>

--- a/src/Parsers/ContextFreeGrammar/Fix/FixRelated.v
+++ b/src/Parsers/ContextFreeGrammar/Fix/FixRelated.v
@@ -74,7 +74,8 @@ Section grammar_fixedpoint.
     Proof.
       pose proof (related_aggregate_state_max initial_nonterminals_data HRbot) as H.
       unfold aggregate_state_relation in *.
-      rewrite PositiveMapExtensions.lift_relation_hetero_iff in *.
+      rewrite PositiveMapExtensions.lift_relation_hetero_iff in *. (* more powerful in econstr than it was in trunk; I think the econstr behavior is correct, but it should be marked as an explicit incompatibility *)
+      rewrite <- ?PositiveMapExtensions.lift_relation_hetero_iff in H.
       (*pose proof (@find_pre_Fix_grammar _ gdata0 G) as H0.
       pose proof (@find_pre_Fix_grammar _ gdata1 G) as H1.
       pose proof (fun nt => transitivity (symmetry (H0 nt)) (H1 nt)) as H01; clear H0 H1.


### PR DESCRIPTION
This fixes the compilation of fiat-parsers with Coq trunk since the merge of the EConstr branch. It should be backward compatible with 8.6.