### PR TITLE
Remove uses of deprecated appcontext.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,22 +262,22 @@ else
 ifneq (,$(filter 8.6%,$(COQ_VERSION)))
 EXPECTED_EXT:=.v86
 ML_DESCRIPTION := "Coq v8.6"
-OTHERFLAGS += -w "-deprecated-appcontext -notation-overridden"
+OTHERFLAGS += -w "-notation-overridden"
 else
 ifneq (,$(filter 8.7%,$(COQ_VERSION)))
 EXPECTED_EXT:=.v87
 ML_DESCRIPTION := "Coq v8.7"
-OTHERFLAGS += -w "-deprecated-appcontext -notation-overridden"
+OTHERFLAGS += -w "-notation-overridden"
 else
 ifneq (,$(filter trunk,$(COQ_VERSION)))
 EXPECTED_EXT:=.trunk
 ML_DESCRIPTION := "Coq trunk"
-OTHERFLAGS += -w "-deprecated-appcontext -notation-overridden"
+OTHERFLAGS += -w "-notation-overridden"
 else
 ifneq (,$(filter master,$(COQ_VERSION)))
 EXPECTED_EXT:=.master
 ML_DESCRIPTION := "Coq master"
-OTHERFLAGS += -w "-deprecated-appcontext -notation-overridden"
+OTHERFLAGS += -w "-notation-overridden"
 else
 ifeq ($(NOT_EXISTS_LOC_DUMMY_LOC),1) # <= 8.4
 EXPECTED_EXT:=.v84
@@ -285,7 +285,7 @@ ML_DESCRIPTION := "Coq v8.4"
 else
 EXPECTED_EXT:=.trunk
 ML_DESCRIPTION := "Coq trunk"
-OTHERFLAGS += -w "-deprecated-appcontext -notation-overridden"
+OTHERFLAGS += -w "-notation-overridden"
 endif
 endif
 endif

--- a/src/CertifiedExtraction/ExtendedPropertiesOfTelescopes.v
+++ b/src/CertifiedExtraction/ExtendedPropertiesOfTelescopes.v
@@ -262,13 +262,13 @@ Qed.
 
 Ltac is_dirty_telescope term :=
   match term with
-  | appcontext[DropName] => idtac
+  | context[DropName] => idtac
   | _ => fail 1
   end.
 
 Ltac is_clean_telescope term :=
   match term with
-  | appcontext[DropName] => fail 1
+  | context[DropName] => fail 1
   | _ => idtac
   end.
 

--- a/src/CertifiedExtraction/Extraction/BinEncoders/BinEncoders.v
+++ b/src/CertifiedExtraction/Extraction/BinEncoders/BinEncoders.v
@@ -71,7 +71,7 @@ Ltac _compile_encode_list :=
   match_ProgOk
     ltac:(fun prog pre post ext env =>
             lazymatch post with
-            | appcontext[fold_left (encode_list_body _) (`?lst)] =>
+            | context[fold_left (encode_list_body _) (`?lst)] =>
               lazymatch pre with
               | context[Cons (NTSome ?vlst) (ret lst) _] =>
                 _compile_LoopMany vlst;
@@ -122,7 +122,7 @@ Ltac encode_list_body_simpl :=
 
 Ltac encode_list__cleanup_post_encode_list_as_fold :=
   lazymatch goal with
-  | [  |- appcontext[fold_left (@encode_list_body _ _ ?cache ?transformer _)] ] =>
+  | [  |- context[fold_left (@encode_list_body _ _ ?cache ?transformer _)] ] =>
     change_post_into_TelAppend; (* FIXME: Need either this, or a set_evars call; why? *)
     setoid_rewrite (encode_list_post_transform_TelEq_TelAppend cache transformer)
   end.
@@ -205,7 +205,7 @@ Definition Counted {A} (x: A) := x.
 Ltac count_instances head_symbol counter_var :=
   pose 0 as counter_var;
   repeat match goal with
-         | [  |- appcontext C [head_symbol ?x] ] =>
+         | [  |- context C [head_symbol ?x] ] =>
            apply_in_body counter_var S;
            let C' := context C[(Counted head_symbol) x] in change C'
          end;

--- a/src/CertifiedExtraction/Extraction/Extraction.v
+++ b/src/CertifiedExtraction/Extraction/Extraction.v
@@ -171,10 +171,10 @@ Ltac _compile_rewrite_if :=
   match_ProgOk
      ltac:(fun prog pre post ext env =>
              match post with
-             | appcontext [if ?b then ?x else ?y] =>
+             | context [if ?b then ?x else ?y] =>
                is_dec b; first [ rewrite (dec2bool_correct b x y)
                                | setoid_rewrite (dec2bool_correct b x y) ]
-             | appcontext [?f (if ?b then ?x else ?y)] =>
+             | context [?f (if ?b then ?x else ?y)] =>
                is_pushable_head_constant f; first [ rewrite (push_if f x y b)
                                                   | setoid_rewrite (push_if f x y b) ]
              end).

--- a/src/Common.v
+++ b/src/Common.v
@@ -254,7 +254,7 @@ Ltac apply_in_hyp_no_match lem :=
   match goal with
   | [ H : _ |- _ ] => apply lem in H;
       match type of H with
-      | appcontext[match _ with _ => _ end] => fail 1
+      | context[match _ with _ => _ end] => fail 1
       | _ => idtac
       end
   end.
@@ -265,16 +265,16 @@ Ltac apply_in_hyp_no_cbv_match lem :=
     => apply lem in H;
       cbv beta iota in H;
       match type of H with
-      | appcontext[match _ with _ => _ end] => fail 1
+      | context[match _ with _ => _ end] => fail 1
       | _ => idtac
       end
   end.
 
 Ltac destruct_sum_in_match' :=
   match goal with
-  | [ H : appcontext[match ?E with inl _ => _ | inr _ => _ end] |- _ ]
+  | [ H : context[match ?E with inl _ => _ | inr _ => _ end] |- _ ]
     => destruct E
-  | [ |- appcontext[match ?E with inl _ => _ | inr _ => _ end] ]
+  | [ |- context[match ?E with inl _ => _ | inr _ => _ end] ]
     => destruct E
   end.
 Ltac destruct_sum_in_match := repeat destruct_sum_in_match'.
@@ -294,7 +294,7 @@ Hint Extern 10 (Proper _ _) => progress cbv beta : typeclass_instances.
 
 Ltac set_evars :=
   repeat match goal with
-         | [ |- appcontext[?E] ] => is_evar E; let H := fresh in set (H := E)
+         | [ |- context[?E] ] => is_evar E; let H := fresh in set (H := E)
          end.
 
 Ltac subst_evars :=
@@ -1324,12 +1324,12 @@ Qed.
 Ltac instantiate_evar :=
   instantiate;
   match goal with
-  | [ H : appcontext[?E] |- _ ]
+  | [ H : context[?E] |- _ ]
     => is_evar E;
       match goal with
       | [ H' : _ |- _ ] => unify E H'
       end
-  | [ |- appcontext[?E] ]
+  | [ |- context[?E] ]
     => is_evar E;
       match goal with
       | [ H' : _ |- _ ] => unify E H'
@@ -1743,13 +1743,13 @@ Global Hint Extern 0 (@eq_refl_vm_cast_r ?T ?x ?y) => clear; abstract (vm_cast_n
 
 Ltac uneta_fun :=
   repeat match goal with
-         | [ |- appcontext[fun ch : ?T => ?f ch] ]
+         | [ |- context[fun ch : ?T => ?f ch] ]
            => progress change (fun ch : T => f ch) with f
          end.
 Ltac uneta_fun_in_hyps :=
   repeat match goal with
-         | [ H : appcontext[fun ch : ?T => ?f ch] |- _ ]
+         | [ H : context[fun ch : ?T => ?f ch] |- _ ]
            => progress change (fun ch : T => f ch) with f in H
-         | [ H := appcontext[fun ch : ?T => ?f ch] |- _ ]
+         | [ H := context[fun ch : ?T => ?f ch] |- _ ]
            => progress change (fun ch : T => f ch) with f in (value of H)
          end.

--- a/src/Common/FMapExtensions.v
+++ b/src/Common/FMapExtensions.v
@@ -1620,9 +1620,9 @@ Module FMapExtensions_fun (E: DecidableType) (Import M: WSfun E).
                                   <- fold_1
           | should_convert_from_to (@fold_left) (@fold_right);
             match goal with
-            | [ |- appcontext[fold_left (fun a b => ?g (@?f b) a)] ]
+            | [ |- context[fold_left (fun a b => ?g (@?f b) a)] ]
               => rewrite (@ListFacts.fold_map _ _ _ _ (fun a b => g b a) f), <- fold_left_rev_right, <- map_rev
-            | [ H : appcontext[fold_left (fun a b => ?g (@?f b) a)] |- _ ]
+            | [ H : context[fold_left (fun a b => ?g (@?f b) a)] |- _ ]
               => rewrite (@ListFacts.fold_map _ _ _ _ (fun a b => g b a) f), <- fold_left_rev_right, <- map_rev in H
             end
           | should_convert_from_to (@fold_right) (@List.In);

--- a/src/Common/List/ListFacts.v
+++ b/src/Common/List/ListFacts.v
@@ -981,8 +981,8 @@ Section ListFacts.
        | [ H : forall x, _ = x \/ _ -> _ |- _ ] => pose proof (H _ (or_introl eq_refl)); specialize (fun x pf => H x (or_intror pf))
        | [ H : ?x = None |- context[?x] ] => rewrite H
        | [ H : S _ = S _ |- _ ] => inversion H; clear H
-       | [ H : appcontext[first_index_helper] |- _ ] => rewrite first_index_helper_first_index_error in H
-       | [ |- appcontext[first_index_helper] ] => rewrite first_index_helper_first_index_error
+       | [ H : context[first_index_helper] |- _ ] => rewrite first_index_helper_first_index_error in H
+       | [ |- context[first_index_helper] ] => rewrite first_index_helper_first_index_error
        | [ H : option_rect _ _ _ ?v = Some _ |- _ ] => destruct v eqn:?; simpl in H
        | [ H : option_rect _ _ _ ?v = None |- _ ] => destruct v eqn:?; simpl in H
        | _ => progress unfold BoolFacts.Bool.bool_rect_nodep in *

--- a/src/Common/MSetExtensions.v
+++ b/src/Common/MSetExtensions.v
@@ -251,7 +251,7 @@ Module MSetExtensionsOn (E: DecidableType) (Import M: WSetsOn E).
     repeat match goal with
            | [ H : elements ?v = _ |- _ ]
              => rewrite !H
-           | [ H : elements ?v = _, H' : appcontext[elements ?v] |- _ ]
+           | [ H : elements ?v = _, H' : context[elements ?v] |- _ ]
              => rewrite !H in H'
            end.
   Ltac InA_concretize_step :=

--- a/src/Common/Monad.v
+++ b/src/Common/Monad.v
@@ -85,7 +85,7 @@ Local Ltac t_option :=
            | _ => assumption
            | _ => solve [ trivial ]
            | [ H : option _ |- _ ] => destruct H
-           | [ |- appcontext[match ?a with None => _ end] ] => case_eq a
+           | [ |- context[match ?a with None => _ end] ] => case_eq a
            | [ |- @bind ?M ?H ?A ?B ?x _ = bind ?x _ ] => let lem := constr:(@bind_ext M H _ A B) in apply lem
            | [ |- @bind ?M ?H ?A ?B ?x _ = ?x ] => etransitivity; [ | solve [ apply (@unit_bind M H _) ] ]
            | _ => progress autorewrite with monad; try assumption; []

--- a/src/Common/Tactics/BreakMatch.v
+++ b/src/Common/Tactics/BreakMatch.v
@@ -6,7 +6,7 @@ Require Import Fiat.Common.Tactics.Head.
    as [if]s), and finally matches in general. *)
 Ltac set_match_refl v' only_when :=
   lazymatch goal with
-  | [ |- appcontext G[match ?e with _ => _ end eq_refl] ]
+  | [ |- context G[match ?e with _ => _ end eq_refl] ]
     => only_when e;
        let T := fresh in
        evar (T : Type); evar (v' : T);
@@ -19,7 +19,7 @@ Ltac set_match_refl v' only_when :=
   end.
 Ltac set_match_refl_hyp v' only_when :=
   lazymatch goal with
-  | [ H : appcontext G[match ?e with _ => _ end eq_refl] |- _ ]
+  | [ H : context G[match ?e with _ => _ end eq_refl] |- _ ]
     => only_when e;
        let T := fresh in
        evar (T : Type); evar (v' : T);
@@ -53,12 +53,12 @@ Ltac destruct_rewrite_sumbool e :=
   try lazymatch type of H with
       | ?LHS = ?RHS
         => lazymatch RHS with
-           | appcontext[LHS] => fail
+           | context[LHS] => fail
            | _ => idtac
            end;
            rewrite ?H; rewrite ?H in *;
            repeat match goal with
-                  | [ |- appcontext G[LHS] ]
+                  | [ |- context G[LHS] ]
                     => let LHS' := fresh in
                        pose LHS as LHS';
                        let G' := context G[LHS'] in
@@ -69,31 +69,31 @@ Ltac destruct_rewrite_sumbool e :=
       end.
 Ltac break_match_step only_when :=
   match goal with
-  | [ |- appcontext[match ?e with _ => _ end] ]
+  | [ |- context[match ?e with _ => _ end] ]
     => only_when e; is_var e; destruct e
-  | [ |- appcontext[match ?e with _ => _ end] ]
+  | [ |- context[match ?e with _ => _ end] ]
     => only_when e;
        match type of e with
        | sumbool _ _ => destruct_rewrite_sumbool e
        end
-  | [ |- appcontext[if ?e then _ else _] ]
+  | [ |- context[if ?e then _ else _] ]
     => only_when e; destruct e eqn:?
-  | [ |- appcontext[match ?e with _ => _ end] ]
+  | [ |- context[match ?e with _ => _ end] ]
     => only_when e; destruct e eqn:?
   | _ => let v := fresh in set_match_refl v only_when; destruct_by_existing_equation v
   end.
 Ltac break_match_hyps_step only_when :=
   match goal with
-  | [ H : appcontext[match ?e with _ => _ end] |- _ ]
+  | [ H : context[match ?e with _ => _ end] |- _ ]
     => only_when e; is_var e; destruct e
-  | [ H : appcontext[match ?e with _ => _ end] |- _ ]
+  | [ H : context[match ?e with _ => _ end] |- _ ]
     => only_when e;
        match type of e with
        | sumbool _ _ => destruct_rewrite_sumbool e
        end
-  | [ H : appcontext[if ?e then _ else _] |- _ ]
+  | [ H : context[if ?e then _ else _] |- _ ]
     => only_when e; destruct e eqn:?
-  | [ H : appcontext[match ?e with _ => _ end] |- _ ]
+  | [ H : context[match ?e with _ => _ end] |- _ ]
     => only_when e; destruct e eqn:?
   | _ => let v := fresh in set_match_refl_hyp v only_when; destruct_by_existing_equation v
   end.
@@ -113,12 +113,12 @@ Ltac break_match_when_head T := repeat break_match_when_head_step T.
 Ltac break_match_hyps_when_head T := repeat break_match_hyps_when_head_step T.
 Ltac break_innermost_match_step :=
   break_match_step ltac:(fun v => lazymatch v with
-                                  | appcontext[match _ with _ => _ end] => fail
+                                  | context[match _ with _ => _ end] => fail
                                   | _ => idtac
                                   end).
 Ltac break_innermost_match_hyps_step :=
   break_match_hyps_step ltac:(fun v => lazymatch v with
-                                       | appcontext[match _ with _ => _ end] => fail
+                                       | context[match _ with _ => _ end] => fail
                                        | _ => idtac
                                        end).
 Ltac break_innermost_match := repeat break_innermost_match_step.

--- a/src/Common/Tactics/FreeIn.v
+++ b/src/Common/Tactics/FreeIn.v
@@ -1,6 +1,6 @@
 Ltac free_in x y :=
   idtac;
   match y with
-  | appcontext[x] => fail 1 x "appears in" y
+  | context[x] => fail 1 x "appears in" y
   | _ => idtac
   end.

--- a/src/Common/Tactics/SetoidSubst.v
+++ b/src/Common/Tactics/SetoidSubst.v
@@ -7,8 +7,8 @@ Ltac setoid_subst''_x_on_left H R x y :=
   rewrite ?H;
   repeat setoid_rewrite H;
   repeat match goal with
-         | [ H' : appcontext[x] |- _ ] => not constr_eq H' H; rewrite H in H'
-         | [ H' : appcontext[x] |- _ ] => not constr_eq H' H; setoid_rewrite H in H'
+         | [ H' : context[x] |- _ ] => not constr_eq H' H; rewrite H in H'
+         | [ H' : context[x] |- _ ] => not constr_eq H' H; setoid_rewrite H in H'
          end;
   clear H;
   clear x.
@@ -19,8 +19,8 @@ Ltac setoid_subst''_x_on_right H R x y :=
   rewrite <- ?H;
   repeat setoid_rewrite <- H;
   repeat match goal with
-         | [ H' : appcontext[x] |- _ ] => not constr_eq H' H; rewrite <- H in H'
-         | [ H' : appcontext[x] |- _ ] => not constr_eq H' H; setoid_rewrite <- H in H'
+         | [ H' : context[x] |- _ ] => not constr_eq H' H; rewrite <- H in H'
+         | [ H' : context[x] |- _ ] => not constr_eq H' H; setoid_rewrite <- H in H'
          end;
   clear H;
   clear x.

--- a/src/Common/Wf.v
+++ b/src/Common/Wf.v
@@ -515,7 +515,7 @@ Section wf.
                      [ clear n1'; revert n0'
                      | apply H
                      | lazymatch goal with
-                       | [ |- appcontext[@nat_eq_transfer iterated_prod n1' n0'] ]
+                       | [ |- context[@nat_eq_transfer iterated_prod n1' n0'] ]
                          => pose proof (@nat_eq_transfer_neq iterated_prod n1' n0') as H';
                             cbv beta in *;
                             generalize dependent (nat_eq_transfer iterated_prod n1' n0');
@@ -524,7 +524,7 @@ Section wf.
                             [ apply EqNat.beq_nat_true_iff in Heq; subst; rewrite <- EqNat.beq_nat_refl in H;
                               exfalso; clear -H; congruence
                             | ]
-                       | [ |- appcontext[@nat_eq_transfer iterated_prod n0' n1'] ]
+                       | [ |- context[@nat_eq_transfer iterated_prod n0' n1'] ]
                          => pose proof (@nat_eq_transfer_neq iterated_prod n0' n1') as H';
                             cbv beta in *;
                             generalize dependent (nat_eq_transfer iterated_prod n0' n1');

--- a/src/Common/Wf1.v
+++ b/src/Common/Wf1.v
@@ -15,7 +15,7 @@ Local Ltac Fix_eq_t F_ext Rwf :=
   rewrite <- Fix_F_eq;
   apply F_ext; intros;
   repeat match goal with
-           | [ |- appcontext[Fix_F _ _ (?f ?x)] ] => generalize (f x)
+           | [ |- context[Fix_F _ _ (?f ?x)] ] => generalize (f x)
          end;
   clear -F_ext Rwf;
   match goal with
@@ -231,7 +231,7 @@ Section FixVTransfer.
         end.
         reflexivity. }
       lazymatch goal with
-        | [ |- appcontext[FixV' ?F] ]
+        | [ |- context[FixV' ?F] ]
           => generalize (FixV' F)
       end.
       subst F'; cbv beta.
@@ -239,7 +239,7 @@ Section FixVTransfer.
       intro.
       rewrite flatten_forall_eq_rect_trans.
       match goal with
-        | [ |- appcontext[flatten_forall_eq_rect
+        | [ |- context[flatten_forall_eq_rect
                             (flattenT_unapply_Proper ?P ?Q ?H)
                             (flatten_forall_unapply ?f)] ]
           => rewrite (@flatten_forall_eq_rect_flattenT_unapply_Proper _ P Q H f)
@@ -248,17 +248,17 @@ Section FixVTransfer.
       { apply flatten_forall_eq_rect_Proper.
         apply flatten_forall_unapply_Proper; intro.
         match goal with
-          | [ |- appcontext[@transitivity _ (@eq ?A) ?P] ]
+          | [ |- context[@transitivity _ (@eq ?A) ?P] ]
             => change (@transitivity _ (@eq ?A) P) with (@eq_trans A)
         end.
         match goal with
-          | [ |- appcontext[@symmetry _ (@eq ?A) ?P] ]
+          | [ |- context[@symmetry _ (@eq ?A) ?P] ]
             => change (@symmetry _ (@eq ?A) P) with (@eq_sym A)
         end.
         set_evars.
         rewrite @transport_pp.
         match goal with
-          | [ |- appcontext G[eq_rect _ (fun T => T) (flatten_forall_apply (flatten_forall_unapply ?k) ?x0) _ (eq_sym (flattenT_apply_unapply ?f1 ?x0))] ]
+          | [ |- context G[eq_rect _ (fun T => T) (flatten_forall_apply (flatten_forall_unapply ?k) ?x0) _ (eq_sym (flattenT_apply_unapply ?f1 ?x0))] ]
             => let H := fresh in
                pose proof (@eq_rect_symmetry_flattenT_apply_unapply _ f1 x0 k) as H;
                  cbv beta in H |- *;

--- a/src/Common/Wf2.v
+++ b/src/Common/Wf2.v
@@ -19,14 +19,14 @@ Local Ltac tuplify a b :=
 Local Ltac tuplify' a b :=
   tuplify a b;
   let tac := (fun T => match T with
-                         | appcontext[?P (a, b)]
+                         | context[?P (a, b)]
                            => change (P (a, b)) with (P (fst (a, b), snd (a, b)))
                        end) in
   match goal with
-    | [ |- appcontext[@eq ?T] ] => tac T
-    | [ |- appcontext[@flatten_forall_eq ?B ?T] ] => tac B; tac T
-    | [ |- appcontext[@flatten_forall_eq_with_assumption ?B ?T] ] => tac B; tac T
-    | [ |- appcontext[@flatten_append_forall ?B ?T] ] => tac B; tac T
+    | [ |- context[@eq ?T] ] => tac T
+    | [ |- context[@flatten_forall_eq ?B ?T] ] => tac B; tac T
+    | [ |- context[@flatten_forall_eq_with_assumption ?B ?T] ] => tac B; tac T
+    | [ |- context[@flatten_append_forall ?B ?T] ] => tac B; tac T
   end.
 
 (** work around https://coq.inria.fr/bugs/show_bug.cgi?id=4471 *)
@@ -180,7 +180,7 @@ Local Ltac Fix2_eq_t F_ext Rwf :=
   rewrite <- Fix2_F_eq;
   apply F_ext; intros;
   repeat match goal with
-           | [ |- appcontext[Fix2_F _ _ (?f ?x)] ] => generalize (f x)
+           | [ |- context[Fix2_F _ _ (?f ?x)] ] => generalize (f x)
          end;
   clear -F_ext Rwf;
   let y := match goal with |- forall x : Acc _ (?y, ?y'), _ => constr:(y) end in
@@ -444,7 +444,7 @@ Section Fix2VTransfer.
         end.
         reflexivity. }
       lazymatch goal with
-        | [ |- appcontext[Fix2V' ?F] ]
+        | [ |- context[Fix2V' ?F] ]
           => generalize (Fix2V' F)
       end.
       subst F'; cbv beta.
@@ -452,7 +452,7 @@ Section Fix2VTransfer.
       intro.
       rewrite flatten_forall_eq_rect_trans.
       match goal with
-        | [ |- appcontext[flatten_forall_eq_rect
+        | [ |- context[flatten_forall_eq_rect
                             (flattenT_unapply_Proper ?P ?Q ?H)
                             (flatten_forall_unapply ?f)] ]
           => rewrite (@flatten_forall_eq_rect_flattenT_unapply_Proper _ P Q H f)
@@ -461,17 +461,17 @@ Section Fix2VTransfer.
       { apply flatten_forall_eq_rect_Proper.
         apply flatten_forall_unapply_Proper; intro.
         match goal with
-          | [ |- appcontext[@transitivity _ (@eq ?A) ?P] ]
+          | [ |- context[@transitivity _ (@eq ?A) ?P] ]
             => change (@transitivity _ (@eq ?A) P) with (@eq_trans A)
         end.
         match goal with
-          | [ |- appcontext[@symmetry _ (@eq ?A) ?P] ]
+          | [ |- context[@symmetry _ (@eq ?A) ?P] ]
             => change (@symmetry _ (@eq ?A) P) with (@eq_sym A)
         end.
         set_evars.
         rewrite @transport_pp.
         match goal with
-          | [ |- appcontext G[eq_rect _ (fun T => T) (flatten_forall_apply (flatten_forall_unapply ?k) ?x0) _ (eq_sym (flattenT_apply_unapply ?f1 ?x0))] ]
+          | [ |- context G[eq_rect _ (fun T => T) (flatten_forall_apply (flatten_forall_unapply ?k) ?x0) _ (eq_sym (flattenT_apply_unapply ?f1 ?x0))] ]
             => let H := fresh in
                pose proof (@eq_rect_symmetry_flattenT_apply_unapply _ f1 x0 k) as H;
                  cbv beta in H |- *;

--- a/src/Computation/Monad.v
+++ b/src/Computation/Monad.v
@@ -128,9 +128,9 @@ Hint Rewrite @refineEquiv_bind_bind @refineEquiv_bind_unit @refineEquiv_unit_bin
     "Anomaly: Uncaught exception
     Invalid_argument("decomp_pointwise"). Please report." *)
 Tactic Notation "autosetoid_rewrite" "with" "refine_monad" :=
-  repeat first [ match goal with |- appcontext[Bind (Bind _ _)] => idtac end;
+  repeat first [ match goal with |- context[Bind (Bind _ _)] => idtac end;
                  setoid_rewrite refineEquiv_bind_bind
-               | match goal with |- appcontext[Bind (Return _)] => idtac end;
+               | match goal with |- context[Bind (Return _)] => idtac end;
                  setoid_rewrite refineEquiv_bind_unit
                | setoid_rewrite refineEquiv_unit_bind ].
 

--- a/src/Examples/DnsServer/DnsAutomation.v
+++ b/src/Examples/DnsServer/DnsAutomation.v
@@ -385,7 +385,7 @@ Ltac Finish_Master BuildEarlyBag BuildLastBag :=
   eapply FullySharpened_Finish;
   [pose_headings_all;
    match goal with
-   | |- appcontext[ @BuildADT (IndexedQueryStructure ?Schema ?Indexes) ] =>
+   | |- context[ @BuildADT (IndexedQueryStructure ?Schema ?Indexes) ] =>
      FullySharpenQueryStructure'' Schema Indexes
    end
   | simpl; pose_string_ids; pose_headings_all;

--- a/src/Examples/HACMSDemo/HACMSDemo.v
+++ b/src/Examples/HACMSDemo/HACMSDemo.v
@@ -464,7 +464,7 @@ Definition Empty : CacheEncode := tt.
 
   Ltac decompose_EnumField Ridx Fidx :=
     match goal with
-      |- appcontext[ @BuildADT (UnConstrQueryStructure (QueryStructureSchemaRaw ?qs_schema)) ]
+      |- context[ @BuildADT (UnConstrQueryStructure (QueryStructureSchemaRaw ?qs_schema)) ]
       =>
       let n := eval compute in (NumAttr (GetHeading qs_schema Ridx)) in
     let AbsR' := constr:(@DecomposeRawQueryStructureSchema_AbsR' n qs_schema ``Ridx ``Fidx id (fun i => ibound (indexb i))

--- a/src/Examples/QueryStructure/BookstoreFacade.v
+++ b/src/Examples/QueryStructure/BookstoreFacade.v
@@ -187,7 +187,7 @@ Proof.
   + unfold CallBagFind, CallBagInsert.
     pose_headings_all.
     match goal with
-    | |- appcontext[ @BuildADT (IndexedQueryStructure ?Schema ?Indexes) ] =>
+    | |- context[ @BuildADT (IndexedQueryStructure ?Schema ?Indexes) ] =>
       FullySharpenQueryStructure Schema Indexes
     end.
 

--- a/src/Examples/QueryStructure/IncompleteROSMaster.v
+++ b/src/Examples/QueryStructure/IncompleteROSMaster.v
@@ -103,7 +103,7 @@ Ltac implement_bag_methods :=
   (* Clean up any leftover CallBagImplMethods *)
   repeat (cbv beta; simpl;
           match goal with
-                |- appcontext[CallBagImplMethod] =>
+                |- context[CallBagImplMethod] =>
                 unfold CallBagImplMethod; cbv beta; simpl;
                 try remove_spurious_Dep_Type_BoundedIndex_nth_eq
           end);
@@ -238,7 +238,7 @@ Ltac Finish_Master BuildEarlyBag BuildLastBag :=
     eapply FullySharpened_Finish;
     [pose_headings_all;
       match goal with
-      | |- appcontext[ @BuildADT (IndexedQueryStructure ?Schema ?Indexes) ] =>
+      | |- context[ @BuildADT (IndexedQueryStructure ?Schema ?Indexes) ] =>
         FullySharpenQueryStructure'' Schema Indexes
       end
     | simpl; pose_string_ids; pose_headings_all;

--- a/src/Examples/QueryStructure/ProcessScheduler.v
+++ b/src/Examples/QueryStructure/ProcessScheduler.v
@@ -112,7 +112,7 @@ Proof.
   - unfold CallBagFind, CallBagInsert.
     pose_headings_all;
       match goal with
-      | |- appcontext[ @BuildADT (IndexedQueryStructure ?Schema ?Indexes) ] =>
+      | |- context[ @BuildADT (IndexedQueryStructure ?Schema ?Indexes) ] =>
         FullySharpenQueryStructure Schema Indexes
       end.
 Defined.

--- a/src/Examples/QueryStructure/StocksFacade.v
+++ b/src/Examples/QueryStructure/StocksFacade.v
@@ -207,7 +207,7 @@ Proof.
   + unfold CallBagFind, CallBagInsert.
     pose_headings_all.
     match goal with
-    | |- appcontext[ @BuildADT (IndexedQueryStructure ?Schema ?Indexes) ] =>
+    | |- context[ @BuildADT (IndexedQueryStructure ?Schema ?Indexes) ] =>
       FullySharpenQueryStructure Schema Indexes
     end.
 

--- a/src/Examples/QueryStructure/WeatherFacade.v
+++ b/src/Examples/QueryStructure/WeatherFacade.v
@@ -156,7 +156,7 @@ Proof.
   + unfold CallBagFind, CallBagInsert.
     pose_headings_all.
     match goal with
-    | |- appcontext[ @BuildADT (IndexedQueryStructure ?Schema ?Indexes) ] =>
+    | |- context[ @BuildADT (IndexedQueryStructure ?Schema ?Indexes) ] =>
       FullySharpenQueryStructure Schema Indexes
     end.
 

--- a/src/Examples/Tutorial/Tutorial.v
+++ b/src/Examples/Tutorial/Tutorial.v
@@ -180,7 +180,7 @@ Ltac final_optimizations := eapply FullySharpened_Finish.
 
 Ltac determinize :=
   match goal with
-  | |- appcontext[ @BuildADT (IndexedQueryStructure ?Schema ?Indexes) ] =>
+  | |- context[ @BuildADT (IndexedQueryStructure ?Schema ?Indexes) ] =>
     FullySharpenQueryStructure Schema Indexes
   end.
 

--- a/src/FiniteSetADTs/FiniteSetRefinement.v
+++ b/src/FiniteSetADTs/FiniteSetRefinement.v
@@ -1285,7 +1285,7 @@ Section FiniteSetHelpers.
     rewrite EnsembleOfList_In in *.
     rewrite In_UniqueFilterOfList in *.
     repeat match goal with
-             | [ |- appcontext[if ?E then _ else _] ] => case_eq E
+             | [ |- context[if ?E then _ else _] ] => case_eq E
              | _ => intro
              | _ => progress subst
              | _ => reflexivity
@@ -1413,45 +1413,45 @@ Tactic Notation "finish" "sharpening" "computation" := finish_FullySharpenedComp
 
 Ltac finite_set_sharpen_step FiniteSetImpl :=
   first [ progress autorewrite with refine_monad
-        | match goal with |- appcontext[Bind (Bind _ _)] => idtac end;
+        | match goal with |- context[Bind (Bind _ _)] => idtac end;
           setoid_rewrite refineEquiv_bind_bind
-        | match goal with |- appcontext[Bind (Return _)] => idtac end;
+        | match goal with |- context[Bind (Return _)] => idtac end;
           setoid_rewrite refineEquiv_bind_unit
-        | match goal with |- appcontext[Bind _ (Return _)] => idtac end;
+        | match goal with |- context[Bind _ (Return _)] => idtac end;
           setoid_rewrite refineEquiv_unit_bind
         | idtac;
           (* do an explicit [match] to avoid "Anomaly: Uncaught exception Invalid_argument("decomp_pointwise"). Please report." *)
           match goal with
-            | |- appcontext[@FiniteSetADT.cardinal] => idtac
-            | |- appcontext[@Ensembles.Cardinal.cardinal] => idtac
+            | |- context[@FiniteSetADT.cardinal] => idtac
+            | |- context[@Ensembles.Cardinal.cardinal] => idtac
           end;
           setoid_rewrite (@finite_set_handle_cardinal FiniteSetImpl)
-        | match goal with |- appcontext[@Ensembles.Union] => idtac end;
+        | match goal with |- context[@Ensembles.Union] => idtac end;
           setoid_rewrite refineEquivUnion; [ | apply Same_set_ELE ]
-        | match goal with |- appcontext[@Ensembles.Complement] => idtac end;
+        | match goal with |- context[@Ensembles.Complement] => idtac end;
           setoid_rewrite Same_set__Intersection_Complement__Setminus
-        | match goal with |- appcontext[@Ensembles.Intersection] => idtac end;
+        | match goal with |- context[@Ensembles.Intersection] => idtac end;
           first [ setoid_rewrite Same_set__Intersection_beq__Setminus
                 | setoid_rewrite Same_set__Intersection_bneq__Setminus
                 | setoid_rewrite Same_set__Intersection_bnneq__Setminus ]
-        (*| match goal with |- appcontext[@Ensembles.Setminus] => idtac end;
+        (*| match goal with |- context[@Ensembles.Setminus] => idtac end;
           setoid_rewrite Same_set_Setminus_fold*)
         | rewrite filter_fold_right
         | progress rewrite ?NoFiniteSetJustFunctionOfList, ?FunctionIsListOfList, ?NoFiniteSetJustListOfList
-        | match goal with |- appcontext[EnsembleListEquivalence (fun x => Ensembles.In _ _ x /\ _)] => idtac end;
+        | match goal with |- context[EnsembleListEquivalence (fun x => Ensembles.In _ _ x /\ _)] => idtac end;
           setoid_rewrite refine_ELE_filter_by_and
-        | match goal with |- appcontext[@FunctionOfList] => idtac end;
+        | match goal with |- context[@FunctionOfList] => idtac end;
           (** N.B. the [not_in] one must come first, so we combine them; if it doesn't come first, then we end up trying to make a finite set out of the complement of a list, which is impossible *)
           first [ setoid_rewrite (@FunctionOfList_pick_not_in FiniteSetImpl)
                 | setoid_rewrite (@FunctionOfList_pick_in FiniteSetImpl) ]
-        | match goal with |- appcontext[@FunctionOfList] => idtac end;
+        | match goal with |- context[@FunctionOfList] => idtac end;
           setoid_rewrite (@FunctionOfList_pull_ret FiniteSetImpl)
-        | match goal with |- appcontext[@FiniteSetAndFunctionOfList] => idtac end;
+        | match goal with |- context[@FiniteSetAndFunctionOfList] => idtac end;
           setoid_rewrite (@FiniteSetAndFunctionOfList_pull_ret FiniteSetImpl)
-        | match goal with |- appcontext[@Ensembles.Intersection] => idtac end;
+        | match goal with |- context[@Ensembles.Intersection] => idtac end;
           setoid_rewrite (@EnsembleListEquivalence_Intersection_elements1_fold FiniteSetImpl)
         | idtac;
-          match goal with |- appcontext[@eq bool] => idtac end;
+          match goal with |- context[@eq bool] => idtac end;
           first [ setoid_rewrite bool_true_iff_beq_pick
                 | setoid_rewrite bool_true_iff_bneq_pick
                 | setoid_rewrite bool_true_iff_bnneq_pick ]

--- a/src/Narcissus/Automation/Solver.v
+++ b/src/Narcissus/Automation/Solver.v
@@ -46,7 +46,7 @@ Ltac makeEvar T k :=
 
 Ltac build_ilist_evar :=
   match goal with
-  | |- appcontext[ith (m := ?n) (B := ?encT) (As := ?q ) ?z] =>
+  | |- context[ith (m := ?n) (B := ?encT) (As := ?q ) ?z] =>
     is_evar z;
     match n with
     | S ?n' => let T := eval simpl in (Vector.hd q) in
@@ -72,10 +72,10 @@ Ltac build_ilist_evar :=
 
 Ltac build_prim_prod_evar :=
   match goal with
-  | |- appcontext[ @ilist.prim_fst ?A unit ?z ?k] =>
+  | |- context[ @ilist.prim_fst ?A unit ?z ?k] =>
     is_evar z;
     makeEvar A ltac:(fun a => unify z (Build_prim_prod a tt))
-  | |- appcontext[ @ilist.prim_fst ?A ?B ?z] =>
+  | |- context[ @ilist.prim_fst ?A ?B ?z] =>
     is_evar z;
     makeEvar A ltac:(fun a =>
                        makeEvar B ltac:(fun b =>
@@ -140,11 +140,11 @@ Ltac start_synthesizing_decoder :=
   match goal with
   | |- CorrectDecoderFor ?Invariant ?Spec =>
     try unfold Spec; try unfold Invariant
-  | |- appcontext [CorrectDecoder _ ?dataInv ?restInv ?formatSpec] =>
+  | |- context [CorrectDecoder _ ?dataInv ?restInv ?formatSpec] =>
     first [unfold dataInv
           | unfold restInv
           | unfold formatSpec ]
-  | |- appcontext [CorrectDecoder _ ?dataInv ?restInv (?formatSpec _)] =>
+  | |- context [CorrectDecoder _ ?dataInv ?restInv (?formatSpec _)] =>
     first [unfold dataInv
           | unfold restInv
           | unfold formatSpec ]
@@ -491,7 +491,7 @@ Ltac Vector_of_evar n T k :=
 Ltac decode_step cleanup_tac :=
   (* Processes the goal by either: *)
   match goal with
-  | |- appcontext [CorrectDecoder _ _ _ ?H _ _] =>
+  | |- context [CorrectDecoder _ _ _ ?H _ _] =>
     progress unfold H
 
   (* D) Solving the goal once all the byte string has been parsed *)
@@ -502,45 +502,45 @@ Ltac decode_step cleanup_tac :=
            [ build_fully_determined_type cleanup_tac
            | decide_data_invariant ] ]
 
-  | |- appcontext [format_unused_word] =>
+  | |- context [format_unused_word] =>
     unfold format_unused_word
   (* A) decomposing one of the parser combinators, *)
   | |- _ => apply_compose
   (* B) applying one of the rules for a base type  *)
   | H : cache_inv_Property _ _
-    |- appcontext [CorrectDecoder _ _ _ format_word _ _] =>
+    |- context [CorrectDecoder _ _ _ format_word _ _] =>
     intros; revert H; eapply Word_decode_correct
-  | |- appcontext [CorrectDecoder _ _ _ (format_unused_word' _ _) _ _] =>
+  | |- context [CorrectDecoder _ _ _ (format_unused_word' _ _) _ _] =>
     let H := eval simpl in unused_word_decode_correct in
         apply H
 
-  | |- appcontext [CorrectDecoder _ _ _ (format_Vector _) _ _] =>
+  | |- context [CorrectDecoder _ _ _ (format_Vector _) _ _] =>
     intros; eapply Vector_decode_correct
 
-  | |- appcontext [CorrectDecoder _ _ _ format_word _ _] =>
+  | |- context [CorrectDecoder _ _ _ format_word _ _] =>
     eapply Word_decode_correct
-  | |- appcontext [CorrectDecoder _ _ _ (format_nat _) _ _] =>
+  | |- context [CorrectDecoder _ _ _ (format_nat _) _ _] =>
     eapply Nat_decode_correct
-  | |- appcontext [CorrectDecoder _ _ _ (format_list _) _ _] => intros; apply FixList_decode_correct
+  | |- context [CorrectDecoder _ _ _ (format_list _) _ _] => intros; apply FixList_decode_correct
 
-  | |- appcontext [CorrectDecoder _ _ _ (format_bool) _ _] =>
+  | |- context [CorrectDecoder _ _ _ (format_bool) _ _] =>
     apply bool_decode_correct
 
-  | |- appcontext [CorrectDecoder _ _ _ (format_bool) _ _] =>
+  | |- context [CorrectDecoder _ _ _ (format_bool) _ _] =>
     eapply bool_decode_correct
 
-  | |- appcontext [CorrectDecoder _ _ _ (format_option _ _) _ _] =>
+  | |- context [CorrectDecoder _ _ _ (format_option _ _) _ _] =>
     intros; eapply option_format_correct;
     [ match goal with
         H : cache_inv_Property _ _ |- _ => eexact H
       end | .. ]
 
-  | |- appcontext [CorrectDecoder _ _ _ (format_enum ?tb) _ _] =>
+  | |- context [CorrectDecoder _ _ _ (format_enum ?tb) _ _] =>
     eapply (@Enum_decode_correct _ _ _ _ _ _ _ tb)
 
-  | |- appcontext[CorrectDecoder _ _ _ format_string _ _ ] =>
+  | |- context[CorrectDecoder _ _ _ format_string _ _ ] =>
     eapply String_decode_correct
-  | |- appcontext [CorrectDecoder _ _ _ (format_SumType (B := ?B) (cache := ?cache) (m := ?n) ?types _) _ _] =>
+  | |- context [CorrectDecoder _ _ _ (format_SumType (B := ?B) (cache := ?cache) (m := ?n) ?types _) _ _] =>
     let cache_inv_H := fresh in
     intros cache_inv_H;
     first

--- a/src/Narcissus/BinLib/Core.v
+++ b/src/Narcissus/BinLib/Core.v
@@ -51,7 +51,7 @@ Record ByteString :=
 
 Local Ltac destruct_matches :=
   repeat match goal with
-         | [ |- appcontext[match ?e with _ => _ end] ] => destruct e eqn:?
+         | [ |- context[match ?e with _ => _ end] ] => destruct e eqn:?
          end.
 
 Definition ByteString_push

--- a/src/Narcissus/Examples/DNS/DnsOpt.v
+++ b/src/Narcissus/Examples/DNS/DnsOpt.v
@@ -1059,14 +1059,14 @@ Section DnsPacket.
   Ltac decode_DNS_rules g :=
     (* Processes the goal by either: *)
     lazymatch goal with
-    | |- appcontext[CorrectDecoder _ _ _ _ format_DomainName _ _ ] =>
+    | |- context[CorrectDecoder _ _ _ _ format_DomainName _ _ ] =>
       eapply (DomainName_decode_correct
                 IndependentCaches IndependentCaches' IndependentCaches'''
                 getDistinct getDistinct' addPeekSome
                 boundPeekSome addPeekNone addPeekNone'
                 addZeroPeek addPeekESome boundPeekESome
                 addPeekENone addPeekENone' addZeroPeekE)
-    | |- appcontext [CorrectDecoder _ _ _ _ (format_list format_resource_Spec) _ _] =>
+    | |- context [CorrectDecoder _ _ _ _ (format_list format_resource_Spec) _ _] =>
       intros; apply FixList_decode_correct with (A_predicate := resourceRecord_OK)
     end.
 

--- a/src/Narcissus/Examples/DNS/SimpleDnsOpt.v
+++ b/src/Narcissus/Examples/DNS/SimpleDnsOpt.v
@@ -666,14 +666,14 @@ Qed.
   Ltac decode_DNS_rules g :=
     (* Processes the goal by either: *)
     lazymatch goal with
-    | |- appcontext[CorrectDecoder _ _ _ format_DomainName _ _ ] =>
+    | |- context[CorrectDecoder _ _ _ format_DomainName _ _ ] =>
       eapply (DomainName_decode_correct
                 IndependentCaches IndependentCaches' IndependentCaches'''
                 getDistinct getDistinct' addPeekSome
                 boundPeekSome addPeekNone addPeekNone'
                 addZeroPeek addPeekESome boundPeekESome
                 addPeekENone addPeekENone')
-    | |- appcontext [CorrectDecoder _ _ _ (format_list format_resource) _ _] =>
+    | |- context [CorrectDecoder _ _ _ (format_list format_resource) _ _] =>
       intros; apply FixList_decode_correct with (A_predicate := resourceRecord_OK)
     end.
 

--- a/src/Narcissus/Examples/NetworkStack/EthernetFrame.v
+++ b/src/Narcissus/Examples/NetworkStack/EthernetFrame.v
@@ -221,7 +221,7 @@ Ltac start_synthesizing_decoder :=
   (* Unfold formatr specification and the data and packet invariants *)
   repeat
     match goal with
-      |- appcontext [CorrectDecoder _ ?dataInv ?restInv ?formatSpec] =>
+      |- context [CorrectDecoder _ ?dataInv ?restInv ?formatSpec] =>
       first [unfold dataInv
             | unfold restInv
             | unfold formatSpec ]
@@ -234,16 +234,16 @@ Ltac start_synthesizing_decoder :=
 Ltac decode_step :=
   match goal with
   | |- _ => apply_compose
-  | |- appcontext [CorrectDecoder _ _ _ (format_Vector _) _ _] =>
+  | |- context [CorrectDecoder _ _ _ (format_Vector _) _ _] =>
     intros; eapply Vector_decode_correct
   | H : cache_inv_Property _ _
-    |- appcontext [CorrectDecoder _ _ _ format_word _ _] =>
+    |- context [CorrectDecoder _ _ _ format_word _ _] =>
     intros; revert H; eapply Word_decode_correct
-  | |- appcontext [CorrectDecoder _ _ _ format_word _ _] =>
+  | |- context [CorrectDecoder _ _ _ format_word _ _] =>
     eapply Word_decode_correct
-  | |- appcontext [CorrectDecoder _ _ _ (format_nat _) _ _] =>
+  | |- context [CorrectDecoder _ _ _ (format_nat _) _ _] =>
     eapply Nat_decode_correct
-  | |- appcontext [CorrectDecoder _ _ _ (format_enum _) _ _] =>
+  | |- context [CorrectDecoder _ _ _ (format_enum _) _ _] =>
     eapply Enum_decode_correct
   | |- NoDupVector _ => Discharge_NoDupVector
   | |- context[Vector_predicate_rest (fun _ _ => True) _ _ _ _] =>

--- a/src/QueryStructure/Automation/AutoDB.v
+++ b/src/QueryStructure/Automation/AutoDB.v
@@ -1191,7 +1191,7 @@ Ltac implement_bag_constructors :=
                  eapply Lookup_Iterate_Dep_Type; simpl; intuition ]
          | |- context[CallBagConstructor ?ridx ?cidx ?d] =>
            match goal with
-             |- appcontext[@Build_IndexedQueryStructure_Impl_AbsR
+             |- context[@Build_IndexedQueryStructure_Impl_AbsR
                              ?qs_schema ?Index
                              ?DelegateReps ?DelegateImpls ?ValidImpls] =>
              let r_o' := fresh "r_o'" in
@@ -1730,7 +1730,7 @@ Ltac Implement_Bound_Join_Comp_Lists' :=
   (* Clean up any leftover CallBagImplMethods *)
   repeat (cbv beta; simpl;
           match goal with
-            |- appcontext[CallBagImplMethod] =>
+            |- context[CallBagImplMethod] =>
             unfold CallBagImplMethod; cbv beta; simpl;
             try remove_spurious_Dep_Type_BoundedIndex_nth_eq
           end);
@@ -2249,7 +2249,7 @@ Ltac implement_bag_methods :=
   (* Clean up any leftover CallBagImplMethods *)
   repeat (cbv beta; simpl;
           match goal with
-                |- appcontext[CallBagImplMethod] =>
+                |- context[CallBagImplMethod] =>
                 unfold CallBagImplMethod; cbv beta; simpl;
                 try remove_spurious_Dep_Type_BoundedIndex_nth_eq
           end);
@@ -2624,10 +2624,10 @@ Ltac plan CreateTerm EarlyIndex LastIndex
      makeClause_dep EarlyIndex_dep LastIndex_dep :=
   match goal with
   | |- context[QSEmptySpec _] => initializer
-  | |- appcontext[EnsembleInsert] =>
+  | |- context[EnsembleInsert] =>
     insertion CreateTerm EarlyIndex LastIndex
               makeClause_dep EarlyIndex_dep LastIndex_dep
-  | |- appcontext[EnsembleDelete] =>
+  | |- context[EnsembleDelete] =>
     deletion CreateTerm EarlyIndex LastIndex
              makeClause_dep EarlyIndex_dep LastIndex_dep
   | |- _ =>
@@ -2705,7 +2705,7 @@ Ltac implement_drill CreateTerm EarlyIndex LastIndex :=
           end;
           pose_headings_all;
           match goal with
-            | |- appcontext[@BuildADT (IndexedQueryStructure ?Schema ?Indexes)] =>
+            | |- context[@BuildADT (IndexedQueryStructure ?Schema ?Indexes)] =>
               FullySharpenQueryStructure Schema Indexes
           end
          )

--- a/src/QueryStructure/Automation/General/QueryAutomation.v
+++ b/src/QueryStructure/Automation/General/QueryAutomation.v
@@ -18,7 +18,7 @@ Require Import Coq.Strings.String Coq.Lists.List Coq.Sorting.Permutation
 Tactic Notation "drop" "constraints" "from" "query" :=
   simplify with monad laws;
   repeat match goal with
-             |- appcontext[@Query_In ?ResultT ?qs_schema ?qs ?R] =>
+             |- context[@Query_In ?ResultT ?qs_schema ?qs ?R] =>
              let H' := fresh in
              pose (@DropQSConstraintsQuery_In ResultT qs_schema qs R) as H';
                simpl in H'; fold_string_hyps_in H'; fold_heading_hyps_in H';

--- a/src/QueryStructure/Automation/MasterPlan.v
+++ b/src/QueryStructure/Automation/MasterPlan.v
@@ -10,7 +10,7 @@ Ltac Implement_Bags BuildEarlyBag BuildLastBag :=
     eapply FullySharpened_Finish;
     [pose_headings_all;
       match goal with
-      | |- appcontext[ @BuildADT (IndexedQueryStructure ?Schema ?Indexes) ] =>
+      | |- context[ @BuildADT (IndexedQueryStructure ?Schema ?Indexes) ] =>
         FullySharpenQueryStructure Schema Indexes
       end
     | simpl; pose_string_ids; pose_headings_all;

--- a/src/QueryStructure/Automation/SearchTerms/RangeSearchTerms.v
+++ b/src/QueryStructure/Automation/SearchTerms/RangeSearchTerms.v
@@ -348,9 +348,9 @@ Proof.
     repeat first [
              solve [ eauto ]
            | match goal with
-             | |- appcontext[Nat_as_OT.compare ?st ?st'] =>
+             | |- context[Nat_as_OT.compare ?st ?st'] =>
                destruct (Nat_as_OT.compare st st'); simpl
-             | |- appcontext[le_dec ?st ?st'] =>
+             | |- context[le_dec ?st ?st'] =>
                destruct (le_dec st st'); simpl
              end
            | progress (unfold Nat_as_OT.lt, Nat_as_OT.eq in *; omega)

--- a/src/QueryStructure/Implementation/DataStructures/Bags/BagsTactics.v
+++ b/src/QueryStructure/Implementation/DataStructures/Bags/BagsTactics.v
@@ -15,7 +15,7 @@ Ltac is_sumbool expr :=
 
 Ltac unfold_functions expr :=
   match expr with
-    | appcontext [ ?f _ ] => unfold f
+    | context [ ?f _ ] => unfold f
   end.
 
 Ltac destruct_ifs_inside conditional :=
@@ -76,7 +76,7 @@ Tactic Notation
        "using" "search" "term" constr(keyword) :=
   match goal with
     | [ H: EnsembleBagEquivalence ?bag_plus ?table ?storage
-        |- appcontext [ filter ?filter1 (benumerate ?storage) ] ] =>
+        |- context [ filter ?filter1 (benumerate ?storage) ] ] =>
       let temp := fresh in
       let filter2 := constr:(bfind_matcher (Bag := BagPlus indexed_storage)
                                            keyword) in
@@ -162,7 +162,7 @@ Qed.
 
 Ltac refine_bag_update_other_table :=
   match goal with
-    | [ |- appcontext [
+    | [ |- context [
                EnsembleBagEquivalence
                  ?bag
                  (GetUnConstrRelation

--- a/src/QueryStructure/Implementation/Operations/List/ListInsertRefinements.v
+++ b/src/QueryStructure/Implementation/Operations/List/ListInsertRefinements.v
@@ -303,7 +303,7 @@ Qed.
 
 Ltac refine_list_insert_in_other_table :=
   match goal with
-    | [ |- appcontext [
+    | [ |- context [
                EnsembleIndexedListEquivalence
                  (GetUnConstrRelation
                     (UpdateUnConstrRelation ?qs ?index1


### PR DESCRIPTION
`appcontext` is likely to be removed in Coq 8.8 and is semantically equivalent to `context`