### PR TITLE
Change appcontext to context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,7 +277,7 @@ else
 ifneq (,$(filter master,$(COQ_VERSION)))
 EXPECTED_EXT:=.master
 ML_DESCRIPTION := "Coq master"
-OTHERFLAGS += -w "-deprecated-appcontext -notation-overridden"
+OTHERFLAGS += -w "-notation-overridden"
 else
 ifeq ($(NOT_EXISTS_LOC_DUMMY_LOC),1) # <= 8.4
 EXPECTED_EXT:=.v84
@@ -285,7 +285,7 @@ ML_DESCRIPTION := "Coq v8.4"
 else
 EXPECTED_EXT:=.master
 ML_DESCRIPTION := "Coq master"
-OTHERFLAGS += -w "-deprecated-appcontext -notation-overridden"
+OTHERFLAGS += -w "-notation-overridden"
 endif
 endif
 endif

--- a/src/Common.v
+++ b/src/Common.v
@@ -254,7 +254,7 @@ Ltac apply_in_hyp_no_match lem :=
   match goal with
   | [ H : _ |- _ ] => apply lem in H;
       match type of H with
-      | appcontext[match _ with _ => _ end] => fail 1
+      | context[match _ with _ => _ end] => fail 1
       | _ => idtac
       end
   end.
@@ -265,16 +265,16 @@ Ltac apply_in_hyp_no_cbv_match lem :=
     => apply lem in H;
       cbv beta iota in H;
       match type of H with
-      | appcontext[match _ with _ => _ end] => fail 1
+      | context[match _ with _ => _ end] => fail 1
       | _ => idtac
       end
   end.
 
 Ltac destruct_sum_in_match' :=
   match goal with
-  | [ H : appcontext[match ?E with inl _ => _ | inr _ => _ end] |- _ ]
+  | [ H : context[match ?E with inl _ => _ | inr _ => _ end] |- _ ]
     => destruct E
-  | [ |- appcontext[match ?E with inl _ => _ | inr _ => _ end] ]
+  | [ |- context[match ?E with inl _ => _ | inr _ => _ end] ]
     => destruct E
   end.
 Ltac destruct_sum_in_match := repeat destruct_sum_in_match'.
@@ -294,7 +294,7 @@ Hint Extern 10 (Proper _ _) => progress cbv beta : typeclass_instances.
 
 Ltac set_evars :=
   repeat match goal with
-         | [ |- appcontext[?E] ] => is_evar E; let H := fresh in set (H := E)
+         | [ |- context[?E] ] => is_evar E; let H := fresh in set (H := E)
          end.
 
 Ltac subst_evars :=
@@ -1324,12 +1324,12 @@ Qed.
 Ltac instantiate_evar :=
   instantiate;
   match goal with
-  | [ H : appcontext[?E] |- _ ]
+  | [ H : context[?E] |- _ ]
     => is_evar E;
       match goal with
       | [ H' : _ |- _ ] => unify E H'
       end
-  | [ |- appcontext[?E] ]
+  | [ |- context[?E] ]
     => is_evar E;
       match goal with
       | [ H' : _ |- _ ] => unify E H'
@@ -1743,13 +1743,13 @@ Global Hint Extern 0 (@eq_refl_vm_cast_r ?T ?x ?y) => clear; abstract (vm_cast_n
 
 Ltac uneta_fun :=
   repeat match goal with
-         | [ |- appcontext[fun ch : ?T => ?f ch] ]
+         | [ |- context[fun ch : ?T => ?f ch] ]
            => progress change (fun ch : T => f ch) with f
          end.
 Ltac uneta_fun_in_hyps :=
   repeat match goal with
-         | [ H : appcontext[fun ch : ?T => ?f ch] |- _ ]
+         | [ H : context[fun ch : ?T => ?f ch] |- _ ]
            => progress change (fun ch : T => f ch) with f in H
-         | [ H := appcontext[fun ch : ?T => ?f ch] |- _ ]
+         | [ H := context[fun ch : ?T => ?f ch] |- _ ]
            => progress change (fun ch : T => f ch) with f in (value of H)
          end.

--- a/src/Common/FMapExtensions.v
+++ b/src/Common/FMapExtensions.v
@@ -1620,9 +1620,9 @@ Module FMapExtensions_fun (E: DecidableType) (Import M: WSfun E).
                                   <- fold_1
           | should_convert_from_to (@fold_left) (@fold_right);
             match goal with
-            | [ |- appcontext[fold_left (fun a b => ?g (@?f b) a)] ]
+            | [ |- context[fold_left (fun a b => ?g (@?f b) a) _ _] ]
               => rewrite (@ListFacts.fold_map _ _ _ _ (fun a b => g b a) f), <- fold_left_rev_right, <- map_rev
-            | [ H : appcontext[fold_left (fun a b => ?g (@?f b) a)] |- _ ]
+            | [ H : context[fold_left (fun a b => ?g (@?f b) a) _ _] |- _ ]
               => rewrite (@ListFacts.fold_map _ _ _ _ (fun a b => g b a) f), <- fold_left_rev_right, <- map_rev in H
             end
           | should_convert_from_to (@fold_right) (@List.In);

--- a/src/Common/MSetExtensions.v
+++ b/src/Common/MSetExtensions.v
@@ -251,7 +251,7 @@ Module MSetExtensionsOn (E: DecidableType) (Import M: WSetsOn E).
     repeat match goal with
            | [ H : elements ?v = _ |- _ ]
              => rewrite !H
-           | [ H : elements ?v = _, H' : appcontext[elements ?v] |- _ ]
+           | [ H : elements ?v = _, H' : context[elements ?v] |- _ ]
              => rewrite !H in H'
            end.
   Ltac InA_concretize_step :=

--- a/src/Common/Monad.v
+++ b/src/Common/Monad.v
@@ -85,7 +85,7 @@ Local Ltac t_option :=
            | _ => assumption
            | _ => solve [ trivial ]
            | [ H : option _ |- _ ] => destruct H
-           | [ |- appcontext[match ?a with None => _ end] ] => case_eq a
+           | [ |- context[match ?a with None => _ end] ] => case_eq a
            | [ |- @bind ?M ?H ?A ?B ?x _ = bind ?x _ ] => let lem := constr:(@bind_ext M H _ A B) in apply lem
            | [ |- @bind ?M ?H ?A ?B ?x _ = ?x ] => etransitivity; [ | solve [ apply (@unit_bind M H _) ] ]
            | _ => progress autorewrite with monad; try assumption; []

--- a/src/Common/Tactics/BreakMatch.v
+++ b/src/Common/Tactics/BreakMatch.v
@@ -6,7 +6,7 @@ Require Import Fiat.Common.Tactics.Head.
    as [if]s), and finally matches in general. *)
 Ltac set_match_refl v' only_when :=
   lazymatch goal with
-  | [ |- appcontext G[match ?e with _ => _ end eq_refl] ]
+  | [ |- context G[match ?e with _ => _ end eq_refl] ]
     => only_when e;
        let T := fresh in
        evar (T : Type); evar (v' : T);
@@ -19,7 +19,7 @@ Ltac set_match_refl v' only_when :=
   end.
 Ltac set_match_refl_hyp v' only_when :=
   lazymatch goal with
-  | [ H : appcontext G[match ?e with _ => _ end eq_refl] |- _ ]
+  | [ H : context G[match ?e with _ => _ end eq_refl] |- _ ]
     => only_when e;
        let T := fresh in
        evar (T : Type); evar (v' : T);
@@ -53,12 +53,12 @@ Ltac destruct_rewrite_sumbool e :=
   try lazymatch type of H with
       | ?LHS = ?RHS
         => lazymatch RHS with
-           | appcontext[LHS] => fail
+           | context[LHS] => fail
            | _ => idtac
            end;
            rewrite ?H; rewrite ?H in *;
            repeat match goal with
-                  | [ |- appcontext G[LHS] ]
+                  | [ |- context G[LHS] ]
                     => let LHS' := fresh in
                        pose LHS as LHS';
                        let G' := context G[LHS'] in
@@ -69,31 +69,31 @@ Ltac destruct_rewrite_sumbool e :=
       end.
 Ltac break_match_step only_when :=
   match goal with
-  | [ |- appcontext[match ?e with _ => _ end] ]
+  | [ |- context[match ?e with _ => _ end] ]
     => only_when e; is_var e; destruct e
-  | [ |- appcontext[match ?e with _ => _ end] ]
+  | [ |- context[match ?e with _ => _ end] ]
     => only_when e;
        match type of e with
        | sumbool _ _ => destruct_rewrite_sumbool e
        end
-  | [ |- appcontext[if ?e then _ else _] ]
+  | [ |- context[if ?e then _ else _] ]
     => only_when e; destruct e eqn:?
-  | [ |- appcontext[match ?e with _ => _ end] ]
+  | [ |- context[match ?e with _ => _ end] ]
     => only_when e; destruct e eqn:?
   | _ => let v := fresh in set_match_refl v only_when; destruct_by_existing_equation v
   end.
 Ltac break_match_hyps_step only_when :=
   match goal with
-  | [ H : appcontext[match ?e with _ => _ end] |- _ ]
+  | [ H : context[match ?e with _ => _ end] |- _ ]
     => only_when e; is_var e; destruct e
-  | [ H : appcontext[match ?e with _ => _ end] |- _ ]
+  | [ H : context[match ?e with _ => _ end] |- _ ]
     => only_when e;
        match type of e with
        | sumbool _ _ => destruct_rewrite_sumbool e
        end
-  | [ H : appcontext[if ?e then _ else _] |- _ ]
+  | [ H : context[if ?e then _ else _] |- _ ]
     => only_when e; destruct e eqn:?
-  | [ H : appcontext[match ?e with _ => _ end] |- _ ]
+  | [ H : context[match ?e with _ => _ end] |- _ ]
     => only_when e; destruct e eqn:?
   | _ => let v := fresh in set_match_refl_hyp v only_when; destruct_by_existing_equation v
   end.
@@ -113,12 +113,12 @@ Ltac break_match_when_head T := repeat break_match_when_head_step T.
 Ltac break_match_hyps_when_head T := repeat break_match_hyps_when_head_step T.
 Ltac break_innermost_match_step :=
   break_match_step ltac:(fun v => lazymatch v with
-                                  | appcontext[match _ with _ => _ end] => fail
+                                  | context[match _ with _ => _ end] => fail
                                   | _ => idtac
                                   end).
 Ltac break_innermost_match_hyps_step :=
   break_match_hyps_step ltac:(fun v => lazymatch v with
-                                       | appcontext[match _ with _ => _ end] => fail
+                                       | context[match _ with _ => _ end] => fail
                                        | _ => idtac
                                        end).
 Ltac break_innermost_match := repeat break_innermost_match_step.

--- a/src/Common/Tactics/FreeIn.v
+++ b/src/Common/Tactics/FreeIn.v
@@ -1,6 +1,6 @@
 Ltac free_in x y :=
   idtac;
   match y with
-  | appcontext[x] => fail 1 x "appears in" y
+  | context[x] => fail 1 x "appears in" y
   | _ => idtac
   end.

--- a/src/Common/Tactics/SetoidSubst.v
+++ b/src/Common/Tactics/SetoidSubst.v
@@ -7,8 +7,8 @@ Ltac setoid_subst''_x_on_left H R x y :=
   rewrite ?H;
   repeat setoid_rewrite H;
   repeat match goal with
-         | [ H' : appcontext[x] |- _ ] => not constr_eq H' H; rewrite H in H'
-         | [ H' : appcontext[x] |- _ ] => not constr_eq H' H; setoid_rewrite H in H'
+         | [ H' : context[x] |- _ ] => not constr_eq H' H; rewrite H in H'
+         | [ H' : context[x] |- _ ] => not constr_eq H' H; setoid_rewrite H in H'
          end;
   clear H;
   clear x.
@@ -19,8 +19,8 @@ Ltac setoid_subst''_x_on_right H R x y :=
   rewrite <- ?H;
   repeat setoid_rewrite <- H;
   repeat match goal with
-         | [ H' : appcontext[x] |- _ ] => not constr_eq H' H; rewrite <- H in H'
-         | [ H' : appcontext[x] |- _ ] => not constr_eq H' H; setoid_rewrite <- H in H'
+         | [ H' : context[x] |- _ ] => not constr_eq H' H; rewrite <- H in H'
+         | [ H' : context[x] |- _ ] => not constr_eq H' H; setoid_rewrite <- H in H'
          end;
   clear H;
   clear x.

--- a/src/Computation/Monad.v
+++ b/src/Computation/Monad.v
@@ -128,9 +128,9 @@ Hint Rewrite @refineEquiv_bind_bind @refineEquiv_bind_unit @refineEquiv_unit_bin
     "Anomaly: Uncaught exception
     Invalid_argument("decomp_pointwise"). Please report." *)
 Tactic Notation "autosetoid_rewrite" "with" "refine_monad" :=
-  repeat first [ match goal with |- appcontext[Bind (Bind _ _)] => idtac end;
+  repeat first [ match goal with |- context[Bind (Bind _ _) _] => idtac end;
                  setoid_rewrite refineEquiv_bind_bind
-               | match goal with |- appcontext[Bind (Return _)] => idtac end;
+               | match goal with |- context[Bind (Return _) _] => idtac end;
                  setoid_rewrite refineEquiv_bind_unit
                | setoid_rewrite refineEquiv_unit_bind ].
 


### PR DESCRIPTION
Only in files mentioned in fiat-core, fiat-parsers, parsers-examples
targets.  In Coq 8.8, `appcontext` is likely to disappear.

This closes #8.