### PR TITLE
Fix ML4_OR_MLG

### DIFF
--- a/_CoqProject.in
+++ b/_CoqProject.in
@@ -671,9 +671,9 @@ src/QueryStructure/Specification/SearchTerms/InRange.v
 src/QueryStructure/Specification/SearchTerms/ListInclusion.v
 src/QueryStructure/Specification/SearchTerms/ListPrefix.v
 src/Common/Coq__8_4__8_5__Compat.v
-src/Common/Tactics/hint_db_extra_plugin.ml4
+src/Common/Tactics/hint_db_extra_plugin.@ML4_OR_MLG@
 src/Common/Tactics/hint_db_extra_plugin.mllib
 src/Common/Tactics/hint_db_extra_tactics.ml
-src/Common/Tactics/transparent_abstract_plugin.ml4
+src/Common/Tactics/transparent_abstract_plugin.@ML4_OR_MLG@
 src/Common/Tactics/transparent_abstract_plugin.mllib
 src/Common/Tactics/transparent_abstract_tactics.ml


### PR DESCRIPTION
This was failing silently in Coq's CI: building Makefile.coq fails but its included `-include` so no error. Then when we do eg `make parsers` the target depends on `PARSERS_VO` which is built from coq_makefile's `VOFILES`, so with the error it's empty.
I don't know how to fix this silence so I'll let you figure it out.

Part of the cause is the merge at 2ccc0c6c1e7fce377b37092f1fbaa43719190c80 which cancelled a submodule bump in a feature branch, then when the feature was merged a couple days ago in 22e4abb086200e1de6cbabfe94729e25b66b9b2c the submodule in the master branch was silently reverted to an old version.