### PR TITLE
Make trivial instances explicit

### DIFF
--- a/src/Parsers/ContextFreeGrammar/Fix/FromAbstractInterpretationDefinitions.v
+++ b/src/Parsers/ContextFreeGrammar/Fix/FromAbstractInterpretationDefinitions.v
@@ -136,7 +136,7 @@ Section general_fold.
       : Proper (pointwise_relation _ eq ==> eq ==> eq) fold_production' | 2
       := _.
 
-    Global Instance: Params (@fold_production') 5.
+    Global Instance: Params (@fold_production') 5 := {}.
 
     Definition fold_productions'
                (fold_nt : default_nonterminal_carrierT -> state)

--- a/src/Parsers/StringLike/Core.v
+++ b/src/Parsers/StringLike/Core.v
@@ -157,4 +157,4 @@ Global Instance: forall T H,
                     (HSLM : StringLikeMin Char) (HSL : StringLike Char),
                 String -> T Char)
             H
-            3.
+            3 := {}.


### PR DESCRIPTION
This is in preparation for coq/coq#9274.

Should be backward compatible but that remains to be tested.