### PR TITLE
Adapting to Coq PR#8726.

### DIFF
--- a/src/Common/Tactics/transparent_abstract_tactics.ml.v89
+++ b/src/Common/Tactics/transparent_abstract_tactics.ml.v89
@@ -30,7 +30,7 @@ module TRANSPARENT_ABSTRACT =
 
     let tclABSTRACTTERM name_op term tacK =
       (* What's the right default goal kind?*)
-      let default_gk = (Global, false, Proof Theorem) in
+      let default_gk = (Global ImportDefaultBehavior, false, Proof Theorem) in
       let s, gk = match name_op with
         | Some s ->
            (try let _, gk, _ = current_proof_statement () in s, gk


### PR DESCRIPTION
The change is that flag `Global` becomes `Global ImportDefaultBehavior` so as to distinguish it from the kind of globality which does not import the qualified names. See coq/coq#8726.

Note: To be merged synchronously with coq/coq#8726.