### PR TITLE
Add -no-template-check until template inductive types are defined

### DIFF
--- a/_CoqProject.in
+++ b/_CoqProject.in
@@ -1,3 +1,4 @@
+-arg -no-template-check
 -R src Fiat
 -R Bedrock Bedrock
 -I src/Common/Tactics


### PR DESCRIPTION
outside of sections. Adapting to coq/coq#9918

This pull request adds a flag -no-template-check that will be available in 8.10 which turns out a stricter check for template-polymorphic inductives avoiding potential unsoundness. It is not obvious how to port developments using template-polymorphic inductives defined in sections to the new criterion (they are not considered template anymore with the new criterion). You hence have three choices: either rework the development in a backward compatible way to avoid the flag, by moving inductives that you want to be template-polymorphic outside the sections or by declaring them as polymorphic cumulative ones (except they won't be instantiable by Prop levels), or accept this flag for the time being. The hope is to have a sound replacement of template-polymorphic inductives altogether by cumulative sort polymorphic inductives by 8.11, where polymorphic parameters will be instantiable by Prop (as well as SProp) in a sound way.