### PR TITLE
[parsers] Avoid relying on `Export` bugs

### DIFF
--- a/src/Common/Wf1.v
+++ b/src/Common/Wf1.v
@@ -6,6 +6,7 @@ Require Import Fiat.Common.Telescope.Instances.
 Require Import Fiat.Common.Telescope.Equality.
 Require Import Fiat.Common.
 Require Import Fiat.Common.Equality.
+Import Init.Wf.
 
 Set Implicit Arguments.
 

--- a/src/Parsers/ContextFreeGrammar/Notations.v
+++ b/src/Parsers/ContextFreeGrammar/Notations.v
@@ -41,7 +41,7 @@ Module opt'.
   Definition list_of_string := Eval compute in @StringOperations.list_of_string.
   Definition pred := Eval compute in pred.
   Definition length := Eval compute in String.length.
-  Definition substring := Eval compute in substring.
+  Definition substring := Eval compute in String.substring.
 End opt'.
 
 (** single characters are terminals, anything wrapped with "'" is a


### PR DESCRIPTION
See https://github.com/coq/coq/issues/10474 and
https://github.com/coq/coq/issues/10480

This patch should be backward compatible, but that remains to be tested.