### PR TITLE
Having @ in front of a notation variable was tolerated but is now an error

### DIFF
--- a/src/Common/FMapExtensions/LiftRelationInstances.v
+++ b/src/Common/FMapExtensions/LiftRelationInstances.v
@@ -691,7 +691,7 @@ Module FMapExtensionsLiftRelationInstances_fun (E: DecidableType) (Import M: WSf
                     ==> iffR)
                  (lift_relation_hetero R defaultA defaultB)).
     Local Notation inst lem :=
-      (@lem
+      (lem
          _ _ _
          is_true is_true (fun x => x)
          _ _ _ _ _ _


### PR DESCRIPTION
This PR is in anticipation of [Coq PR#11120](https://github.com/coq/coq/pull/11120) which in particular addresses [Coq issue#4690](https://github.com/coq/coq/pull/4690).

In notations, `@` in front of a notation variable was a no-op. It is now an error.

This fiat PR is backward compatible and can be merged as soon as now.