### PR TITLE
Adapt to the removal of the Template Check option.

### DIFF
--- a/src/Parsers/Reflective/Syntax.v
+++ b/src/Parsers/Reflective/Syntax.v
@@ -237,7 +237,7 @@ End args.
 Section term.
   Context (var : TypeCode -> Type).
 
-  Inductive RLiteralConstructor : TypeCode -> Set :=
+  Inductive RLiteralConstructor : TypeCode -> Type :=
   | Rpair {A B : SimpleTypeCode} : RLiteralConstructor (A --> B --> A * B)
   | RS : RLiteralConstructor (cnat --> cnat)
   | RO : RLiteralConstructor cnat
@@ -280,7 +280,7 @@ Section term.
   | Rsplit_string_for_production
     : RLiteralNonConstructor (cnat * (cnat * cnat) --> cnat --> cnat --> (clist cnat)).*)
 
-  Inductive RLiteralTerm (T : TypeCode) : Set :=
+  Inductive RLiteralTerm (T : TypeCode) : Type :=
   | RLC (_ : RLiteralConstructor T)
   | RLNC (_ : RLiteralNonConstructor T).
 


### PR DESCRIPTION
This is backwards compatible and removes a potential source of unsoundness in the code, namely an inductive that should never have landed in `Set`.

See https://github.com/coq/coq/pull/11546.