### PR TITLE
overlay for coq/coq#12162

### DIFF
--- a/src/Computation/Decidable.v
+++ b/src/Computation/Decidable.v
@@ -150,7 +150,7 @@ Global Program Instance nat_eq_Decidable {n m : nat} : Decidable (n = m) := {
 }.
 Obligation 1. t' beq_nat_true_iff. Qed.
 
-Global Program Instance le_Decidable {n m} : Decidable (le n m) := {
+Global Program Instance le_Decidable {n m} : Decidable (Nat.le n m) := {
   Decidable_witness := Compare_dec.leb n m
 }.
 Obligation 1. t' leb_iff. Qed.


### PR DESCRIPTION
The PR coq/coq#12162 renames `Bool.leb` into `Bool.le` which is more coherent with the rest of the standard library since it has type `bool -> bool -> Prop`. This generates possible clashes with `Nat.le` or `Peano.le` so that additional qualification is required.