### PR TITLE
Adapting to Coq PR#12960: implicit arguments not any more lost when nesting applicative notations

### DIFF
--- a/src/Common/FMapExtensions/LiftRelationInstances.v
+++ b/src/Common/FMapExtensions/LiftRelationInstances.v
@@ -441,25 +441,25 @@ Module FMapExtensionsLiftRelationInstances_fun (E: DecidableType) (Import M: WSf
     Local Notation instP lem
       := (inst lem Params3.iffP Params3.iffP_iff).
     Definition lift_relation_gen_hetero_Proper_Proper_subrelation_iffR
-      := inst (@lift_relation_gen_hetero_Proper_Proper_subrelation_gen_iffR).
+      := @inst (@lift_relation_gen_hetero_Proper_Proper_subrelation_gen_iffR).
     Definition lift_relation_gen_hetero_Proper_Proper_subrelation
-      := inst (@lift_relation_gen_hetero_Proper_Proper_subrelation_gen).
+      := @inst (@lift_relation_gen_hetero_Proper_Proper_subrelation_gen).
     Definition lift_relation_gen_hetero_Proper_Proper_subrelation_impl
-      := inst (@lift_relation_gen_hetero_Proper_Proper_subrelation_gen_impl).
+      := @inst (@lift_relation_gen_hetero_Proper_Proper_subrelation_gen_impl).
     Definition lift_relation_gen_hetero_Proper_Proper_subrelation_flip_impl
-      := inst (@lift_relation_gen_hetero_Proper_Proper_subrelation_gen_flip_impl).
+      := @inst (@lift_relation_gen_hetero_Proper_Proper_subrelation_gen_flip_impl).
     Definition lift_relation_gen_hetero_Proper_Proper_subrelation_iffP
-      := instP (@lift_relation_gen_hetero_Proper_Proper_subrelation_gen_iffP).
+      := @instP (@lift_relation_gen_hetero_Proper_Proper_subrelation_gen_iffP).
     Definition lift_relation_gen_hetero_homo_Proper_Proper_subrelation_iffR
-      := inst (@lift_relation_gen_hetero_homo_Proper_Proper_subrelation_gen_iffR).
+      := @inst (@lift_relation_gen_hetero_homo_Proper_Proper_subrelation_gen_iffR).
     Definition lift_relation_gen_hetero_homo_Proper_Proper_subrelation
-      := inst (@lift_relation_gen_hetero_homo_Proper_Proper_subrelation_gen).
+      := @inst (@lift_relation_gen_hetero_homo_Proper_Proper_subrelation_gen).
     Definition lift_relation_gen_hetero_homo_Proper_Proper_subrelation_impl
-      := inst (@lift_relation_gen_hetero_homo_Proper_Proper_subrelation_gen_impl).
+      := @inst (@lift_relation_gen_hetero_homo_Proper_Proper_subrelation_gen_impl).
     Definition lift_relation_gen_hetero_homo_Proper_Proper_subrelation_flip_impl
-      := inst (@lift_relation_gen_hetero_homo_Proper_Proper_subrelation_gen_flip_impl).
+      := @inst (@lift_relation_gen_hetero_homo_Proper_Proper_subrelation_gen_flip_impl).
     Definition lift_relation_gen_hetero_homo_Proper_Proper_subrelation_iffP
-      := inst (@lift_relation_gen_hetero_homo_Proper_Proper_subrelation_gen_iffP).
+      := @inst (@lift_relation_gen_hetero_homo_Proper_Proper_subrelation_gen_iffP).
     Global Existing Instances
            lift_relation_gen_hetero_Proper_Proper_subrelation_iffR
            lift_relation_gen_hetero_Proper_Proper_subrelation


### PR DESCRIPTION
The code was relying on the implicit arguments being lost, so we add an explicit `@` to preserve the previous behavior. See discussion at coq/coq#12960.

This should be backwards compatible (i.e. the corresponding `@`s behave as a no-op before coq/coq#12960).