### PR TITLE
Implicit arguments were formerly inactive in "Context".

### DIFF
--- a/src/Parsers/Reflective/PartialUnfold.v
+++ b/src/Parsers/Reflective/PartialUnfold.v
@@ -42,7 +42,7 @@ Section normalization_by_evaluation.
     := args_for (fun A => option (onelevelG A)).
 
   Section constantOfs.
-    Context (constantOf : forall {T} (t : Term var T), option (onelevelG T)).
+    Context (constantOf : forall T (t : Term var T), option (onelevelG T)).
 
     Definition constantOfs {T} (af : args_for (Term var) T) : args_for_onelevel T :=
       map_args_for constantOf af.
@@ -75,7 +75,7 @@ Section normalization_by_evaluation.
     args_for normalized_of.
 
   Section meanings.
-    Context (meaning : forall {T} (t : Term normalized_of T), normalized_of T).
+    Context (meaning : forall T (t : Term normalized_of T), normalized_of T).
 
     Definition meanings {T} (af : args_for (Term normalized_of) T) : arg_meanings_for T :=
       map_args_for meaning af.


### PR DESCRIPTION
Implicit arguments in `Context` were discarded. Coq PR [#11390](https://github.com/coq/coq/pull/11390) preserves them. The present PR adapts the part of fiat tested on Coq CI to the new semantics.

I removed the declaration of the implicit arguments which were discarded anyway. In particular, the PR is backwards-compatible and can be merged as soon as now.