### PR TITLE
Adapt to removal of Bracketing Last Introduction Pattern flag.

### DIFF
--- a/src/Common.v
+++ b/src/Common.v
@@ -19,7 +19,6 @@ Require Export Fiat.Common.Coq__8_4__8_5__Compat.
 Global Set Implicit Arguments.
 Global Generalizable All Variables.
 Global Set Asymmetric Patterns.
-Global Unset Bracketing Last Introduction Pattern.
 
 Global Coercion is_true : bool >-> Sortclass.
 Coercion bool_of_sumbool {A B} (x : {A} + {B}) : bool := if x then true else false.

--- a/src/Common/FMapExtensions.v
+++ b/src/Common/FMapExtensions.v
@@ -1469,7 +1469,7 @@ Module FMapExtensions_fun (E: DecidableType) (Import M: WSfun E).
 
   Global Instance eq_key_elt_Equivalence {elt} : Equivalence (@eq_key_elt elt) | 100.
   Proof.
-    split; unfold eq_key_elt; repeat (intros [] || intro); simpl in *; intuition.
+    split; unfold eq_key_elt; repeat intros []; simpl in *; intuition;
     etransitivity; eassumption.
   Qed.
 


### PR DESCRIPTION
Hi, this is a small backward compatible change to adapt to the removal of the Bracketing Last Introduction Pattern flag (coq/coq#13509).