### PR TITLE
Hopefully compat with coq/coq#13741: remove omega

### DIFF
--- a/Bedrock/Nomega.v
+++ b/Bedrock/Nomega.v
@@ -1,6 +1,6 @@
 (* Make [omega] work for [N] *)
 
-Require Import Coq.Arith.Arith Coq.omega.Omega Coq.NArith.NArith.
+Require Import Coq.Arith.Arith Coq.ZArith.ZArith Coq.NArith.NArith.
 
 Local Open Scope N_scope.
 

--- a/Bedrock/Word.v
+++ b/Bedrock/Word.v
@@ -4,7 +4,7 @@ Require Import Coq.Arith.Arith
         Coq.Arith.Div2
         Coq.NArith.NArith
         Coq.Bool.Bool
-        Coq.omega.Omega.
+        Coq.ZArith.ZArith.
 Require Import Bedrock.Nomega.
 
 Set Implicit Arguments.

--- a/src/ADTRefinement/FixedPoint.v
+++ b/src/ADTRefinement/FixedPoint.v
@@ -109,7 +109,7 @@ Proof.
     constructor; intros.
   contradiction (NPeano.Nat.nlt_0_r _ H).
   apply IHlen.
-  Require Import Omega.
+  Require Import Coq.ZArith.ZArith.
   omega.
 Qed.
 

--- a/src/CertifiedExtraction/Extraction/Gensym.v
+++ b/src/CertifiedExtraction/Extraction/Gensym.v
@@ -3,7 +3,7 @@ Require Import Coq.Numbers.Natural.Peano.NPeano
         Coq.Arith.Lt
         Coq.Arith.Compare_dec
         Coq.Lists.List
-        Coq.omega.Omega.
+        Coq.ZArith.ZArith.
 
 Section GenSym.
   Local Unset Implicit Arguments.

--- a/src/Common.v
+++ b/src/Common.v
@@ -1,6 +1,6 @@
 Require Import Coq.Lists.List.
 Require Import Coq.Numbers.Natural.Peano.NPeano.
-Require Import Coq.omega.Omega Coq.Lists.SetoidList.
+Require Import Coq.ZArith.ZArith Coq.Lists.SetoidList.
 Require Export Coq.Setoids.Setoid Coq.Classes.RelationClasses
         Coq.Program.Program Coq.Classes.Morphisms.
 Require Export Fiat.Common.Tactics.SplitInContext.

--- a/src/Common/Ensembles/IndexedEnsembles.v
+++ b/src/Common/Ensembles/IndexedEnsembles.v
@@ -1,6 +1,6 @@
 Require Import Coq.Lists.List
         Coq.Strings.String
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Logic.FunctionalExtensionality
         Coq.Sorting.Permutation Coq.Sets.Ensembles
         Fiat.Common.DecideableEnsembles

--- a/src/Common/Enumerable.v
+++ b/src/Common/Enumerable.v
@@ -1,5 +1,5 @@
 Require Import Coq.Lists.List.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Common.List.Operations.
 Require Import Fiat.Common.List.ListFacts.
 Require Import Fiat.Common.StringFacts.

--- a/src/Common/FixedPoints.v
+++ b/src/Common/FixedPoints.v
@@ -1,4 +1,4 @@
-Require Import Coq.Arith.EqNat Coq.Arith.Compare_dec Coq.omega.Omega.
+Require Import Coq.Arith.EqNat Coq.Arith.Compare_dec Coq.ZArith.ZArith.
 Require Import Coq.Lists.List.
 Require Import Fiat.Common.List.ListFacts.
 Require Import Fiat.Common.

--- a/src/Common/Gensym.v
+++ b/src/Common/Gensym.v
@@ -1,6 +1,6 @@
 (** * Generate a symbol distinct from every element of a list of symbols *)
 (** Assumes a way to generate a new symbol from a pair of symbols "greater" than either one. *)
-Require Import Coq.Classes.RelationClasses Coq.Lists.List Coq.omega.Omega.
+Require Import Coq.Classes.RelationClasses Coq.Lists.List Coq.ZArith.ZArith.
 Require Import Coq.Strings.String Coq.Strings.Ascii.
 Require Import Fiat.Common.StringFacts.
 

--- a/src/Common/Le.v
+++ b/src/Common/Le.v
@@ -1,7 +1,7 @@
 (** * Common facts about [≤] *)
 Require Export Fiat.Common.Coq__8_4__8_5__Compat.
 Require Import Coq.Arith.Le.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Coq.Classes.Morphisms.
 Require Import Coq.Program.Basics.
 

--- a/src/Common/List/ListFacts.v
+++ b/src/Common/List/ListFacts.v
@@ -1,4 +1,4 @@
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Coq.Lists.List Coq.Lists.SetoidList Coq.Bool.Bool
         Fiat.Common Fiat.Common.List.Operations Fiat.Common.Equality Fiat.Common.List.FlattenList Fiat.Common.LogicFacts.
 

--- a/src/Common/NatFacts.v
+++ b/src/Common/NatFacts.v
@@ -1,6 +1,6 @@
 Require Import Coq.Classes.Morphisms.
 Require Import Coq.Numbers.Natural.Peano.NPeano.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 
 Lemma min_def {x y} : min x y = x - (x - y).
 Proof. apply Min.min_case_strong; omega. Qed.

--- a/src/Common/StringFacts.v
+++ b/src/Common/StringFacts.v
@@ -1,4 +1,4 @@
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Coq.Strings.Ascii.
 Require Import Coq.Strings.String.
 Require Import Coq.Numbers.Natural.Peano.NPeano.

--- a/src/Common/String_as_OT.v
+++ b/src/Common/String_as_OT.v
@@ -1,4 +1,4 @@
-Require Import Coq.omega.Omega Coq.Strings.String Coq.Strings.Ascii.
+Require Import Coq.ZArith.ZArith Coq.Strings.String Coq.Strings.Ascii.
 Require Import Coq.Structures.OrderedType.
 
 Lemma nat_compare_eq_refl : forall x, Nat.compare x x = Eq.

--- a/src/Computation/FixComp.v
+++ b/src/Computation/FixComp.v
@@ -1,6 +1,6 @@
 Require Import
         Coq.Sets.Ensembles
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Classes.Morphisms
         Coq.Classes.SetoidTactics
         Fiat.Computation

--- a/src/Examples/CacheADT/CacheADT.v
+++ b/src/Examples/CacheADT/CacheADT.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String Coq.omega.Omega Coq.Lists.List Coq.Logic.FunctionalExtensionality Coq.Sets.Ensembles
+Require Import Coq.Strings.String Coq.ZArith.ZArith Coq.Lists.List Coq.Logic.FunctionalExtensionality Coq.Sets.Ensembles
         Fiat.Computation Fiat.ADT Fiat.ADTRefinement Fiat.ADTNotation Fiat.ADTRefinement.BuildADTRefinements.
 
 Open Scope string_scope.

--- a/src/Examples/CacheADT/CacheRefinements.v
+++ b/src/Examples/CacheADT/CacheRefinements.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String Coq.omega.Omega Coq.Lists.List Coq.Logic.FunctionalExtensionality Coq.Sets.Ensembles
+Require Import Coq.Strings.String Coq.ZArith.ZArith Coq.Lists.List Coq.Logic.FunctionalExtensionality Coq.Sets.Ensembles
         Computation ADT ADTRefinement ADTNotation BuildADTRefinements
         KVEnsembles CacheSpec.
 

--- a/src/Examples/CacheADT/CacheSig.v
+++ b/src/Examples/CacheADT/CacheSig.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String Coq.omega.Omega Coq.Lists.List Coq.Logic.FunctionalExtensionality Coq.Sets.Ensembles
+Require Import Coq.Strings.String Coq.ZArith.ZArith Coq.Lists.List Coq.Logic.FunctionalExtensionality Coq.Sets.Ensembles
         Computation ADT ADTRefinement ADTNotation BuildADTRefinements
         KVEnsembles.
 

--- a/src/Examples/CacheADT/CacheSpec.v
+++ b/src/Examples/CacheADT/CacheSpec.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String Coq.omega.Omega Coq.Lists.List Coq.Logic.FunctionalExtensionality Coq.Sets.Ensembles
+Require Import Coq.Strings.String Coq.ZArith.ZArith Coq.Lists.List Coq.Logic.FunctionalExtensionality Coq.Sets.Ensembles
         Fiat.Computation Fiat.ADT Fiat.ADTRefinement Fiat.ADTNotation Fiat.ADTRefinement.BuildADTRefinements
         Examples.CacheADT.KVEnsembles.
 

--- a/src/Examples/CacheADT/FMapCacheImplementation.v
+++ b/src/Examples/CacheADT/FMapCacheImplementation.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String Coq.omega.Omega Coq.Lists.List Coq.Logic.FunctionalExtensionality Coq.Sets.Ensembles
+Require Import Coq.Strings.String Coq.ZArith.ZArith Coq.Lists.List Coq.Logic.FunctionalExtensionality Coq.Sets.Ensembles
         Computation ADT ADTRefinement ADTNotation BuildADTRefinements
         KVEnsembles CacheSpec CacheRefinements.
 

--- a/src/Examples/CacheADT/LRUCache.v
+++ b/src/Examples/CacheADT/LRUCache.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String Coq.omega.Omega Coq.Lists.List Coq.Logic.FunctionalExtensionality Coq.Sets.Ensembles
+Require Import Coq.Strings.String Coq.ZArith.ZArith Coq.Lists.List Coq.Logic.FunctionalExtensionality Coq.Sets.Ensembles
         Computation ADT ADTRefinement ADTNotation BuildADTRefinements
         KVEnsembles CacheSpec CacheRefinements FMapCacheImplementation.
 

--- a/src/Examples/Tutorial/NotInList.v
+++ b/src/Examples/Tutorial/NotInList.v
@@ -3,7 +3,7 @@ Require Import Coq.Strings.Ascii
         Coq.Lists.List.
 
 Require Export Coq.Vectors.Vector
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Strings.Ascii
         Coq.Bool.Bool
         Coq.Bool.Bvector

--- a/src/Narcissus/Automation/AlignedAutomation.v
+++ b/src/Narcissus/Automation/AlignedAutomation.v
@@ -1,5 +1,5 @@
 Require Import
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Fiat.Narcissus.BinLib
         Fiat.Narcissus.Common.Specs
         Fiat.Narcissus.Common.ComposeOpt

--- a/src/Narcissus/Automation/Common.v
+++ b/src/Narcissus/Automation/Common.v
@@ -1,6 +1,6 @@
 Require Import
         Coq.Bool.Bool
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Fiat.Common.DecideableEnsembles
         Fiat.Common.EnumType
         Fiat.Common.BoundedLookup

--- a/src/Narcissus/Automation/Decision.v
+++ b/src/Narcissus/Automation/Decision.v
@@ -1,6 +1,6 @@
 Require Import
         Coq.Bool.Bool
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Lists.List
         Fiat.Common.DecideableEnsembles
         Fiat.Common.EnumType

--- a/src/Narcissus/Automation/ExtractData.v
+++ b/src/Narcissus/Automation/ExtractData.v
@@ -1,6 +1,6 @@
 Require Import
         Coq.Bool.Bool
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Fiat.Common.DecideableEnsembles
         Fiat.Common.EnumType
         Fiat.Common.BoundedLookup

--- a/src/Narcissus/Automation/NormalizeFormats.v
+++ b/src/Narcissus/Automation/NormalizeFormats.v
@@ -1,6 +1,6 @@
 Require Import
         Coq.Bool.Bool
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Fiat.Common.DecideableEnsembles
         Fiat.Common.EnumType
         Fiat.Common.BoundedLookup

--- a/src/Narcissus/Automation/Solver.v
+++ b/src/Narcissus/Automation/Solver.v
@@ -1,6 +1,6 @@
 Require Import
         Coq.Bool.Bool
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Fiat.Common.DecideableEnsembles
         Fiat.Common.EnumType
         Fiat.Common.BoundedLookup

--- a/src/Narcissus/Automation/SynthesizeDecoder.v
+++ b/src/Narcissus/Automation/SynthesizeDecoder.v
@@ -1,6 +1,6 @@
 Require Import
         Coq.Bool.Bool
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Fiat.Common.DecideableEnsembles
         Fiat.Common.EnumType
         Fiat.Common.BoundedLookup

--- a/src/Narcissus/BinLib/AlignWord.v
+++ b/src/Narcissus/BinLib/AlignWord.v
@@ -11,7 +11,7 @@ Require Import
 
 Require Import
         Coq.Vectors.Vector
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Bedrock.Word.
 
 Section AlignWord.

--- a/src/Narcissus/BinLib/AlignedByteString.v
+++ b/src/Narcissus/BinLib/AlignedByteString.v
@@ -1,6 +1,6 @@
 Require Import
         Bedrock.Word
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.NArith.NArith
         Coq.Arith.Arith
         Coq.Numbers.Natural.Peano.NPeano

--- a/src/Narcissus/BinLib/AlignedDecodeMonad.v
+++ b/src/Narcissus/BinLib/AlignedDecodeMonad.v
@@ -1,6 +1,6 @@
 Require Import
         Bedrock.Word
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.NArith.NArith
         Coq.Arith.Arith
         Coq.Numbers.Natural.Peano.NPeano

--- a/src/Narcissus/BinLib/AlignedDecoders.v
+++ b/src/Narcissus/BinLib/AlignedDecoders.v
@@ -1,5 +1,5 @@
 Require Import
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Strings.String
         Coq.Arith.Mult
         Coq.Vectors.Vector.

--- a/src/Narcissus/BinLib/AlignedDomainName.v
+++ b/src/Narcissus/BinLib/AlignedDomainName.v
@@ -1,5 +1,5 @@
 Require Import
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Strings.String
         Coq.Arith.Mult
         Coq.Vectors.Vector.

--- a/src/Narcissus/BinLib/AlignedEncodeMonad.v
+++ b/src/Narcissus/BinLib/AlignedEncodeMonad.v
@@ -1,6 +1,6 @@
 Require Import
         Bedrock.Word
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.NArith.NArith
         Coq.Arith.Arith
         Coq.Numbers.Natural.Peano.NPeano

--- a/src/Narcissus/BinLib/AlignedIPChecksum.v
+++ b/src/Narcissus/BinLib/AlignedIPChecksum.v
@@ -1,7 +1,7 @@
 Require Import
         Coq.Strings.String
         Coq.Vectors.Vector
-        Coq.omega.Omega.
+        Coq.ZArith.ZArith.
 
 Require Import
         Fiat.Common.SumType

--- a/src/Narcissus/BinLib/AlignedString.v
+++ b/src/Narcissus/BinLib/AlignedString.v
@@ -1,5 +1,5 @@
 Require Import
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Strings.Ascii
         Coq.Strings.String
         Coq.Arith.Mult

--- a/src/Narcissus/BinLib/Core.v
+++ b/src/Narcissus/BinLib/Core.v
@@ -1,6 +1,6 @@
 Require Import
         Bedrock.Word
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.NArith.NArith
         Coq.Arith.Arith
         Coq.Numbers.Natural.Peano.NPeano

--- a/src/Narcissus/Examples/ByteAlignedExample.v
+++ b/src/Narcissus/Examples/ByteAlignedExample.v
@@ -1,5 +1,5 @@
 Require Import
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Strings.String
         Coq.Vectors.Vector.
 

--- a/src/Narcissus/Examples/DNS/DNSPacket.v
+++ b/src/Narcissus/Examples/DNS/DNSPacket.v
@@ -1,6 +1,6 @@
 Require Import
         Coq.Vectors.Vector
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Strings.Ascii
         Coq.Strings.String
         Coq.Bool.Bool

--- a/src/Narcissus/Examples/DNS/RRecordTypes.v
+++ b/src/Narcissus/Examples/DNS/RRecordTypes.v
@@ -1,6 +1,6 @@
 Require Import
         Coq.Vectors.Vector
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Strings.Ascii
         Coq.Strings.String
         Coq.Bool.Bool

--- a/src/Narcissus/Examples/DNS/SimpleDNSPacket.v
+++ b/src/Narcissus/Examples/DNS/SimpleDNSPacket.v
@@ -1,6 +1,6 @@
 Require Import
         Coq.Vectors.Vector
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Strings.Ascii
         Coq.Strings.String
         Coq.Bool.Bool

--- a/src/Narcissus/Examples/DNS/SimpleRRecordTypes.v
+++ b/src/Narcissus/Examples/DNS/SimpleRRecordTypes.v
@@ -1,6 +1,6 @@
 Require Import
         Coq.Vectors.Vector
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Strings.Ascii
         Coq.Strings.String
         Coq.Bool.Bool

--- a/src/Narcissus/Examples/NetworkStack/ARPPacket.v
+++ b/src/Narcissus/Examples/NetworkStack/ARPPacket.v
@@ -1,7 +1,7 @@
 Require Import
         Coq.Strings.String
         Coq.Vectors.Vector
-        Coq.omega.Omega.
+        Coq.ZArith.ZArith.
 
 Require Import
         Fiat.Common.SumType

--- a/src/Narcissus/Examples/NetworkStack/EthernetHeader.v
+++ b/src/Narcissus/Examples/NetworkStack/EthernetHeader.v
@@ -1,7 +1,7 @@
 Require Import
         Coq.Strings.String
         Coq.Vectors.Vector
-        Coq.omega.Omega.
+        Coq.ZArith.ZArith.
 
 Require Import
         Fiat.Common.SumType

--- a/src/Narcissus/Examples/NetworkStack/IPv4Header.v
+++ b/src/Narcissus/Examples/NetworkStack/IPv4Header.v
@@ -1,7 +1,7 @@
 Require Import
         Coq.Strings.String
         Coq.Vectors.Vector
-        Coq.omega.Omega.
+        Coq.ZArith.ZArith.
 
 Require Import
         Fiat.Common.SumType

--- a/src/Narcissus/Examples/NetworkStack/TCP_Packet.v
+++ b/src/Narcissus/Examples/NetworkStack/TCP_Packet.v
@@ -1,7 +1,7 @@
 Require Import
         Coq.Strings.String
         Coq.Vectors.Vector
-        Coq.omega.Omega.
+        Coq.ZArith.ZArith.
 
 Require Import
         Fiat.Common.SumType

--- a/src/Narcissus/Examples/NetworkStack/UDP_Packet.v
+++ b/src/Narcissus/Examples/NetworkStack/UDP_Packet.v
@@ -1,7 +1,7 @@
 Require Import
         Coq.Strings.String
         Coq.Vectors.Vector
-        Coq.omega.Omega.
+        Coq.ZArith.ZArith.
 
 Require Import
         Fiat.Common.SumType

--- a/src/Narcissus/Examples/TutorialPrelude.v
+++ b/src/Narcissus/Examples/TutorialPrelude.v
@@ -1,5 +1,5 @@
 Require Export
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Strings.String
         Coq.Vectors.Vector.
 Require Export

--- a/src/Narcissus/Formats/AsciiOpt.v
+++ b/src/Narcissus/Formats/AsciiOpt.v
@@ -4,7 +4,7 @@ Require Import
         Fiat.Narcissus.Formats.WordOpt.
 Require Import
         Bedrock.Word
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Strings.Ascii
         Coq.Numbers.BinNums
         Coq.NArith.BinNat.

--- a/src/Narcissus/Formats/Base/EnqueueFormat.v
+++ b/src/Narcissus/Formats/Base/EnqueueFormat.v
@@ -1,5 +1,5 @@
 Require Import
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Strings.String
         Coq.Vectors.Vector.
 

--- a/src/Narcissus/Formats/Base/FMapFormat.v
+++ b/src/Narcissus/Formats/Base/FMapFormat.v
@@ -1,5 +1,5 @@
 Require Import
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Strings.String
         Coq.Vectors.Vector.
 

--- a/src/Narcissus/Formats/Base/FixFormat.v
+++ b/src/Narcissus/Formats/Base/FixFormat.v
@@ -1,5 +1,5 @@
 Require Import
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Strings.String
         Coq.Vectors.Vector.
 

--- a/src/Narcissus/Formats/Base/LaxTerminalFormat.v
+++ b/src/Narcissus/Formats/Base/LaxTerminalFormat.v
@@ -1,5 +1,5 @@
 Require Import
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Strings.String
         Coq.Vectors.Vector.
 

--- a/src/Narcissus/Formats/Base/StrictTerminalFormat.v
+++ b/src/Narcissus/Formats/Base/StrictTerminalFormat.v
@@ -1,5 +1,5 @@
 Require Import
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Strings.String
         Coq.Vectors.Vector.
 

--- a/src/Narcissus/Formats/ByteBuffer.v
+++ b/src/Narcissus/Formats/ByteBuffer.v
@@ -1,7 +1,7 @@
 Require Import
         Coq.Arith.Peano_dec
         Coq.Logic.Eqdep_dec
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Fiat.Narcissus.Common.Specs
         Fiat.Narcissus.Formats.WordOpt
         Fiat.Narcissus.Formats.Vector

--- a/src/Narcissus/Formats/DomainNameOpt.v
+++ b/src/Narcissus/Formats/DomainNameOpt.v
@@ -1,6 +1,6 @@
 Require Import
         Bedrock.Word
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Strings.Ascii
         Coq.Strings.String
         Coq.Logic.Eqdep_dec.

--- a/src/Narcissus/Formats/Empty.v
+++ b/src/Narcissus/Formats/Empty.v
@@ -1,5 +1,5 @@
 Require Import
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Fiat.Common
         Fiat.Computation.Notations
         Fiat.Narcissus.Common.Specs

--- a/src/Narcissus/Formats/FixListOpt.v
+++ b/src/Narcissus/Formats/FixListOpt.v
@@ -1,5 +1,5 @@
 Require Import
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Fiat.Narcissus.Common.Notations
         Fiat.Narcissus.Common.Specs
         Fiat.Narcissus.Common.ComposeOpt

--- a/src/Narcissus/Formats/FixStringOpt.v
+++ b/src/Narcissus/Formats/FixStringOpt.v
@@ -3,7 +3,7 @@ Require Import
         Fiat.Narcissus.Formats.AsciiOpt.
 Require Import
         Bedrock.Word
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Strings.Ascii
         Coq.Strings.String.
 

--- a/src/Narcissus/Formats/IPChecksum.v
+++ b/src/Narcissus/Formats/IPChecksum.v
@@ -1,5 +1,5 @@
 Require Import
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Strings.String
         Coq.Vectors.Vector.
 

--- a/src/Narcissus/Formats/InternetChecksum.v
+++ b/src/Narcissus/Formats/InternetChecksum.v
@@ -1,6 +1,6 @@
 Require Import List.
 Require Import Bedrock.Word
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.micromega.Psatz.
 
 Require Import NArith NArithRing.

--- a/src/Narcissus/Formats/NatOpt.v
+++ b/src/Narcissus/Formats/NatOpt.v
@@ -3,7 +3,7 @@ Require Import
         Fiat.Narcissus.BaseFormats
         Fiat.Narcissus.Formats.WordOpt.
 Require Import
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Bedrock.Word.
 
 Section Nat.

--- a/src/Narcissus/Formats/Sequence.v
+++ b/src/Narcissus/Formats/Sequence.v
@@ -1,5 +1,5 @@
 Require Import
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Fiat.Common
         Fiat.Computation.Notations
         Fiat.Narcissus.Common.Specs

--- a/src/Narcissus/Formats/WordOpt.v
+++ b/src/Narcissus/Formats/WordOpt.v
@@ -1,5 +1,5 @@
 Require Import
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Fiat.Common
         Fiat.Computation.Notations
         Fiat.Narcissus.Common.Specs

--- a/src/Narcissus/Stores/DomainNameStore.v
+++ b/src/Narcissus/Stores/DomainNameStore.v
@@ -1,5 +1,5 @@
 Require Import
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Lists.List
         Coq.Strings.String
         Coq.Arith.Mult.

--- a/src/Parsers/BaseTypesLemmas.v
+++ b/src/Parsers/BaseTypesLemmas.v
@@ -1,6 +1,6 @@
 (** * Lemmas about the common part of the interface of the CFG parser *)
 Require Import Coq.Classes.RelationClasses Coq.Setoids.Setoid.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Parsers.ContextFreeGrammar.Core.
 Require Import Fiat.Parsers.BaseTypes.
 

--- a/src/Parsers/ContextFreeGrammar/Carriers.v
+++ b/src/Parsers/ContextFreeGrammar/Carriers.v
@@ -1,4 +1,4 @@
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Common.Enumerable.
 Require Import Fiat.Common.Enumerable.BoolProp.
 Require Import Fiat.Common.List.Operations.

--- a/src/Parsers/ContextFreeGrammar/Fold.v
+++ b/src/Parsers/ContextFreeGrammar/Fold.v
@@ -1,6 +1,6 @@
 (** * A general [fold] over grammars *)
 Require Import Coq.Lists.List.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Parsers.ContextFreeGrammar.Carriers.
 Require Import Fiat.Parsers.ContextFreeGrammar.PreNotations.
 Require Import Fiat.Parsers.ContextFreeGrammar.Core.

--- a/src/Parsers/GenericRecognizer.v
+++ b/src/Parsers/GenericRecognizer.v
@@ -1,6 +1,6 @@
 (** * Definition of a CFG parser-recognizer *)
 Require Import Coq.Lists.List.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Parsers.ContextFreeGrammar.Core.
 Require Import Fiat.Parsers.BaseTypes.
 Require Import Fiat.Parsers.GenericBaseTypes.

--- a/src/Parsers/GenericRecognizerMin.v
+++ b/src/Parsers/GenericRecognizerMin.v
@@ -2,7 +2,7 @@
 Require Import Coq.Lists.List.
 Require Import Coq.Arith.EqNat.
 Require Import Coq.Arith.Compare_dec Coq.Arith.Wf_nat.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Common.List.Operations.
 Require Import Fiat.Parsers.ContextFreeGrammar.Core.
 Require Import Fiat.Parsers.BaseTypes.

--- a/src/Parsers/MinimalParseOfParse.v
+++ b/src/Parsers/MinimalParseOfParse.v
@@ -1,6 +1,6 @@
 (** * Every parse tree has a corresponding minimal parse tree *)
 Require Import Coq.Strings.String Coq.Lists.List.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Parsers.ContextFreeGrammar.Core Fiat.Parsers.ContextFreeGrammar.Properties Fiat.Parsers.WellFoundedParse.
 Require Import Fiat.Parsers.CorrectnessBaseTypes Fiat.Parsers.BaseTypes.
 Require Import Fiat.Parsers.StringLike.Properties.

--- a/src/Parsers/ParserImplementation.v
+++ b/src/Parsers/ParserImplementation.v
@@ -1,5 +1,5 @@
 (** * Implementation of simply-typed interface of the parser *)
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Export Fiat.Parsers.ParserInterface.
 Require Import Fiat.Parsers.ContextFreeGrammar.Core.
 Require Import Fiat.Parsers.ContextFreeGrammar.Properties.

--- a/src/Parsers/Reachable/All/MinimalReachableOfReachable.v
+++ b/src/Parsers/Reachable/All/MinimalReachableOfReachable.v
@@ -1,6 +1,6 @@
 (** * Every parse tree has a corresponding minimal parse tree *)
 Require Import Coq.Strings.String.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Parsers.ContextFreeGrammar.Core.
 Require Import Fiat.Parsers.Reachable.All.Reachable.
 Require Import Fiat.Parsers.Reachable.All.MinimalReachable.

--- a/src/Parsers/Reachable/MaybeEmpty/MinimalOfCore.v
+++ b/src/Parsers/Reachable/MaybeEmpty/MinimalOfCore.v
@@ -1,6 +1,6 @@
 (** * Every parse tree has a corresponding minimal parse tree *)
 Require Import Coq.Strings.String.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Parsers.ContextFreeGrammar.Core.
 Require Import Fiat.Parsers.Reachable.MaybeEmpty.Core.
 Require Import Fiat.Parsers.Reachable.MaybeEmpty.Minimal.

--- a/src/Parsers/Reachable/MaybeEmpty/OfParse.v
+++ b/src/Parsers/Reachable/MaybeEmpty/OfParse.v
@@ -1,6 +1,6 @@
 (** * Every parse tree has a corresponding minimal parse tree *)
 
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Parsers.ContextFreeGrammar.Core.
 Require Import Fiat.Parsers.ContextFreeGrammar.Properties.
 Require Import Fiat.Parsers.StringLike.Properties.

--- a/src/Parsers/Reachable/OnlyFirst/MinimalReachableOfReachable.v
+++ b/src/Parsers/Reachable/OnlyFirst/MinimalReachableOfReachable.v
@@ -1,6 +1,6 @@
 (** * Every parse tree has a corresponding minimal parse tree *)
 Require Import Coq.Strings.String.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Parsers.ContextFreeGrammar.Core.
 Require Import Fiat.Parsers.Reachable.OnlyFirst.Reachable.
 Require Import Fiat.Parsers.Reachable.OnlyFirst.MinimalReachable.

--- a/src/Parsers/Reachable/OnlyLast/MinimalReachableOfReachable.v
+++ b/src/Parsers/Reachable/OnlyLast/MinimalReachableOfReachable.v
@@ -1,6 +1,6 @@
 (** * Every parse tree has a corresponding minimal parse tree *)
 Require Import Coq.Strings.String.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Parsers.ContextFreeGrammar.Core.
 Require Import Fiat.Parsers.Reachable.OnlyLast.Reachable.
 Require Import Fiat.Parsers.Reachable.OnlyLast.MinimalReachable.

--- a/src/Parsers/Reachable/OnlyLast/ReachableParse.v
+++ b/src/Parsers/Reachable/OnlyLast/ReachableParse.v
@@ -1,6 +1,6 @@
 (** * Every parse tree has a corresponding minimal parse tree *)
 
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Parsers.ContextFreeGrammar.Core.
 Require Import Fiat.Parsers.ContextFreeGrammar.Properties.
 Require Import Fiat.Parsers.StringLike.LastChar.

--- a/src/Parsers/Reachable/ParenBalanced/Core.v
+++ b/src/Parsers/Reachable/ParenBalanced/Core.v
@@ -1,5 +1,5 @@
 Require Import Coq.Strings.String Coq.Lists.List.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Parsers.ContextFreeGrammar.Core.
 Require Import Fiat.Parsers.BaseTypes.
 Require Import Fiat.Common.List.Operations.

--- a/src/Parsers/Reachable/ParenBalanced/MinimalOfCore.v
+++ b/src/Parsers/Reachable/ParenBalanced/MinimalOfCore.v
@@ -1,6 +1,6 @@
 (** * Every parse tree has a corresponding minimal parse tree *)
 Require Import Coq.Strings.String.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Parsers.ContextFreeGrammar.Core.
 Require Import Fiat.Parsers.Reachable.ParenBalanced.Core.
 Require Import Fiat.Parsers.Reachable.ParenBalanced.WellFounded.

--- a/src/Parsers/Reachable/ParenBalanced/OfParse.v
+++ b/src/Parsers/Reachable/ParenBalanced/OfParse.v
@@ -1,6 +1,6 @@
 (** * Every parse tree has a corresponding minimal parse tree *)
 
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Parsers.ContextFreeGrammar.Core.
 Require Import Fiat.Parsers.ContextFreeGrammar.Properties.
 Require Import Fiat.Parsers.StringLike.Properties.

--- a/src/Parsers/Reachable/ParenBalancedHiding/MinimalOfCore.v
+++ b/src/Parsers/Reachable/ParenBalancedHiding/MinimalOfCore.v
@@ -1,6 +1,6 @@
 (** * Every parse tree has a corresponding minimal parse tree *)
 Require Import Coq.Strings.String.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Parsers.ContextFreeGrammar.Core.
 Require Import Fiat.Parsers.Reachable.ParenBalanced.Core.
 Require Import Fiat.Parsers.Reachable.ParenBalanced.MinimalOfCore.

--- a/src/Parsers/RecognizerPreOptimized.v
+++ b/src/Parsers/RecognizerPreOptimized.v
@@ -1,5 +1,5 @@
 Require Import Coq.Lists.List.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Coq.Numbers.Natural.Peano.NPeano.
 Require Import Fiat.Parsers.ContextFreeGrammar.Core.
 Require Import Fiat.Parsers.ContextFreeGrammar.PreNotations.

--- a/src/Parsers/Refinement/BinOpBrackets/BinOpRules.v
+++ b/src/Parsers/Refinement/BinOpBrackets/BinOpRules.v
@@ -1,6 +1,6 @@
 (** Refinement rules for binary operations *)
 Require Import Coq.Lists.List.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Computation.Refinements.General.
 Require Import Fiat.Common.
 Require Import Fiat.Common.Equality.

--- a/src/Parsers/Refinement/BinOpBrackets/MakeBinOpTable.v
+++ b/src/Parsers/Refinement/BinOpBrackets/MakeBinOpTable.v
@@ -1,6 +1,6 @@
 (** * Build a table for the next binop at a given level *)
 Require Import Coq.Lists.List.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Common.
 Require Import Fiat.Common.List.Operations.
 Require Import Fiat.Common.List.ListFacts.

--- a/src/Parsers/Refinement/BinOpBrackets/ParenBalanced.v
+++ b/src/Parsers/Refinement/BinOpBrackets/ParenBalanced.v
@@ -1,5 +1,5 @@
 (** * Build a table for the next binop at a given level *)
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Parsers.Reachable.ParenBalanced.Core.
 Require Import Fiat.Parsers.StringLike.Core.
 Require Import Fiat.Parsers.StringLike.Properties.

--- a/src/Parsers/Refinement/BinOpBrackets/ParenBalancedGrammar.v
+++ b/src/Parsers/Refinement/BinOpBrackets/ParenBalancedGrammar.v
@@ -1,5 +1,5 @@
 Require Import Coq.Lists.List Coq.Setoids.Setoid Coq.Classes.Morphisms.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Parsers.Splitters.RDPList.
 Require Import Fiat.Parsers.Refinement.BinOpBrackets.ParenBalanced.
 Require Import Fiat.Parsers.Reachable.ParenBalanced.Core.

--- a/src/Parsers/Refinement/BinOpBrackets/ParenBalancedLemmas.v
+++ b/src/Parsers/Refinement/BinOpBrackets/ParenBalancedLemmas.v
@@ -1,4 +1,4 @@
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Parsers.StringLike.Core.
 Require Import Fiat.Parsers.StringLike.Properties.
 Require Import Fiat.Parsers.Reachable.ParenBalanced.Core.

--- a/src/Parsers/Refinement/DisjointLemmas.v
+++ b/src/Parsers/Refinement/DisjointLemmas.v
@@ -1,6 +1,6 @@
 (** Sharpened ADT for an expression grammar with parentheses *)
 Require Import Coq.Init.Wf Coq.Arith.Wf_nat.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Coq.Lists.List Coq.Strings.String.
 Require Import Coq.Numbers.Natural.Peano.NPeano.
 Require Import Fiat.Parsers.ContextFreeGrammar.Core.

--- a/src/Parsers/Refinement/DisjointRules.v
+++ b/src/Parsers/Refinement/DisjointRules.v
@@ -1,5 +1,5 @@
 (** Refinement rules for disjoint rules *)
-Require Import Coq.omega.Omega Coq.Lists.List.
+Require Import Coq.ZArith.ZArith Coq.Lists.List.
 Require Import Fiat.Parsers.Refinement.PreTactics.
 Require Import Fiat.Computation.Refinements.General.
 Require Import Fiat.Parsers.StringLike.Properties.

--- a/src/Parsers/Refinement/DisjointRulesRev.v
+++ b/src/Parsers/Refinement/DisjointRulesRev.v
@@ -1,5 +1,5 @@
 (** Refinement rules for disjoint rules *)
-Require Import Coq.omega.Omega Coq.Lists.List.
+Require Import Coq.ZArith.ZArith Coq.Lists.List.
 Require Import Fiat.Parsers.Refinement.PreTactics.
 Require Import Fiat.Computation.Refinements.General.
 Require Import Fiat.Parsers.StringLike.LastCharSuchThat.

--- a/src/Parsers/Refinement/EmptyLemmas.v
+++ b/src/Parsers/Refinement/EmptyLemmas.v
@@ -1,4 +1,4 @@
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Parsers.ContextFreeGrammar.Core.
 Require Import Fiat.Parsers.ContextFreeGrammar.PreNotations.
 Require Import Fiat.Parsers.StringLike.Properties.

--- a/src/Parsers/Refinement/FixedLengthLemmas.v
+++ b/src/Parsers/Refinement/FixedLengthLemmas.v
@@ -1,6 +1,6 @@
 Require Import Coq.Init.Wf Coq.Arith.Wf_nat.
 Require Import Coq.Lists.List Coq.Strings.String.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Parsers.ContextFreeGrammar.Core.
 Require Import Fiat.Parsers.ContextFreeGrammar.PreNotations.
 Require Import Fiat.Parsers.ContextFreeGrammar.Precompute.

--- a/src/Parsers/Reflective/LogicalRelations.v
+++ b/src/Parsers/Reflective/LogicalRelations.v
@@ -1,4 +1,4 @@
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Coq.Classes.Morphisms.
 Require Import Fiat.Parsers.Reflective.Syntax Fiat.Parsers.Reflective.Semantics.
 Require Import Fiat.Parsers.Reflective.PartialUnfold.

--- a/src/Parsers/SplitterFromParserADT.v
+++ b/src/Parsers/SplitterFromParserADT.v
@@ -1,6 +1,6 @@
 (*Reference implementation of a splitter and parser based on that splitter *)
 Require Import Coq.Strings.String.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.ADTNotation.BuildADT Fiat.ADTNotation.BuildADTSig.
 Require Import Fiat.ADT.ComputationalADT.
 Require Import Fiat.ADTRefinement.GeneralRefinements.

--- a/src/Parsers/Splitters/BruteForce.v
+++ b/src/Parsers/Splitters/BruteForce.v
@@ -1,6 +1,6 @@
 (** * Definition of a boolean-returning CFG parser-recognizer *)
 Require Import Coq.Lists.List.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Parsers.ContextFreeGrammar.Core.
 Require Import Fiat.Parsers.ContextFreeGrammar.PreNotations.
 Require Import Fiat.Parsers.BaseTypes Fiat.Parsers.CorrectnessBaseTypes.

--- a/src/Parsers/Splitters/RDPList.v
+++ b/src/Parsers/Splitters/RDPList.v
@@ -1,6 +1,6 @@
 (** * Definition of the part of boolean-returning CFG parser-recognizer that instantiates things to lists *)
 Require Import Coq.Lists.List.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Parsers.ContextFreeGrammar.Core.
 Require Import Fiat.Parsers.ContextFreeGrammar.PreNotations.
 Require Import Fiat.Parsers.BaseTypes.

--- a/src/Parsers/StringLike/FirstChar.v
+++ b/src/Parsers/StringLike/FirstChar.v
@@ -1,6 +1,6 @@
 (** * Mapping predicates over [StringLike] things *)
 
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Coq.Numbers.Natural.Peano.NPeano.
 Require Import Fiat.Parsers.StringLike.Core.
 Require Import Fiat.Parsers.StringLike.Properties.

--- a/src/Parsers/StringLike/ForallChars.v
+++ b/src/Parsers/StringLike/ForallChars.v
@@ -1,7 +1,7 @@
 (** * Mapping predicates over [StringLike] things *)
 
 Require Import Coq.Numbers.Natural.Peano.NPeano.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Parsers.StringLike.Core.
 Require Import Fiat.Parsers.StringLike.Properties.
 Require Import Fiat.Common.

--- a/src/Parsers/StringLike/LastChar.v
+++ b/src/Parsers/StringLike/LastChar.v
@@ -1,5 +1,5 @@
 (** * Mapping predicates over [StringLike] things *)
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Coq.Numbers.Natural.Peano.NPeano.
 Require Import Fiat.Parsers.StringLike.Core.
 Require Import Fiat.Parsers.StringLike.Properties.

--- a/src/Parsers/StringLike/LastCharSuchThat.v
+++ b/src/Parsers/StringLike/LastCharSuchThat.v
@@ -1,5 +1,5 @@
 (** * Mapping predicates over [StringLike] things *)
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Coq.Numbers.Natural.Peano.NPeano.
 Require Import Fiat.Parsers.StringLike.Core.
 Require Import Fiat.Parsers.StringLike.Properties.

--- a/src/Parsers/StringLike/OcamlString.v
+++ b/src/Parsers/StringLike/OcamlString.v
@@ -1,5 +1,5 @@
 Require Import Coq.Numbers.Natural.Peano.NPeano.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Coq.Strings.Ascii.
 Require Import Coq.Strings.String.
 Require Import Coq.ZArith.BinInt.

--- a/src/Parsers/StringLike/Properties.v
+++ b/src/Parsers/StringLike/Properties.v
@@ -1,7 +1,7 @@
 (** * Theorems about string-like types *)
 
 Require Import Coq.Numbers.Natural.Peano.NPeano.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Fiat.Common.
 Require Import Fiat.Common.List.Operations.
 Require Import Fiat.Common.List.ListFacts.

--- a/src/Parsers/StringLike/String.v
+++ b/src/Parsers/StringLike/String.v
@@ -1,7 +1,7 @@
 (** * Definitions of some specific string-like types *)
 Require Import Coq.Strings.Ascii.
 Require Import Coq.Strings.String.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 Require Import Coq.Numbers.Natural.Peano.NPeano.
 Require Import Fiat.Common Fiat.Common.Equality.
 Require Import Fiat.Common.StringOperations Fiat.Common.StringFacts.

--- a/src/QueryStructure/Automation/General/DeleteAutomation.v
+++ b/src/QueryStructure/Automation/General/DeleteAutomation.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String Coq.omega.Omega Coq.Lists.List Coq.Logic.FunctionalExtensionality Coq.Sets.Ensembles
+Require Import Coq.Strings.String Coq.ZArith.ZArith Coq.Lists.List Coq.Logic.FunctionalExtensionality Coq.Sets.Ensembles
         Fiat.Common.List.ListFacts
         Fiat.Computation
         Fiat.Common.Tactics.CacheStringConstant

--- a/src/QueryStructure/Automation/General/InsertAutomation.v
+++ b/src/QueryStructure/Automation/General/InsertAutomation.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String Coq.omega.Omega Coq.Lists.List
+Require Import Coq.Strings.String Coq.ZArith.ZArith Coq.Lists.List
         Coq.Logic.FunctionalExtensionality Coq.Sets.Ensembles
         Fiat.Computation
         Fiat.ADT

--- a/src/QueryStructure/Automation/General/QueryStructureAutomation.v
+++ b/src/QueryStructure/Automation/General/QueryStructureAutomation.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String Coq.omega.Omega Coq.Lists.List Coq.Logic.FunctionalExtensionality Coq.Sets.Ensembles
+Require Import Coq.Strings.String Coq.ZArith.ZArith Coq.Lists.List Coq.Logic.FunctionalExtensionality Coq.Sets.Ensembles
         Coq.Sorting.Permutation
         Fiat.Computation
         Fiat.ADT

--- a/src/QueryStructure/Implementation/DataStructures/BagADT/BagADT.v
+++ b/src/QueryStructure/Implementation/DataStructures/BagADT/BagADT.v
@@ -1,5 +1,5 @@
 Require Import Coq.Strings.String
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Lists.List
         Coq.Logic.FunctionalExtensionality
         Coq.Sets.Ensembles

--- a/src/QueryStructure/Implementation/DataStructures/Bags/InvertedIndexBags.v
+++ b/src/QueryStructure/Implementation/DataStructures/Bags/InvertedIndexBags.v
@@ -6,7 +6,7 @@ Require Import
         Coq.FSets.FMapInterface
         Coq.FSets.FMapFacts
         Coq.FSets.FMapAVL
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Fiat.Common
         Fiat.Common.String_as_OT
         Fiat.Common.List.ListFacts

--- a/src/QueryStructure/Implementation/DataStructures/Bags/ListBags.v
+++ b/src/QueryStructure/Implementation/DataStructures/Bags/ListBags.v
@@ -62,7 +62,7 @@ Section ListBags.
     firstorder.
   Qed.
 
-  Require Import Coq.omega.Omega.
+  Require Import Coq.ZArith.ZArith.
   Lemma List_BagCountCorrect_aux :
     forall (container: list TItem) (search_term: TSearchTerm) default,
       length (List.filter (bfind_matcher search_term) container) + default =

--- a/src/QueryStructure/Implementation/DataStructures/Bags/NatCompare_Facts.v
+++ b/src/QueryStructure/Implementation/DataStructures/Bags/NatCompare_Facts.v
@@ -1,4 +1,4 @@
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 
 Hint Rewrite <- nat_compare_lt : hints.
 Hint Rewrite <- nat_compare_gt : hints.

--- a/src/QueryStructure/Implementation/DataStructures/Bags/TrieBags.v
+++ b/src/QueryStructure/Implementation/DataStructures/Bags/TrieBags.v
@@ -4,7 +4,7 @@ Require Import
         Coq.FSets.FMapInterface
         Coq.FSets.FMapFacts
         Coq.FSets.FMapAVL
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Fiat.Common
         Fiat.Common.List.ListFacts
         Fiat.Common.List.FlattenList

--- a/src/QueryStructure/Implementation/Operations/General/DeleteRefinements.v
+++ b/src/QueryStructure/Implementation/Operations/General/DeleteRefinements.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String Coq.omega.Omega Coq.Lists.List Coq.Logic.FunctionalExtensionality Coq.Sets.Ensembles
+Require Import Coq.Strings.String Coq.ZArith.ZArith Coq.Lists.List Coq.Logic.FunctionalExtensionality Coq.Sets.Ensembles
         Fiat.Common.List.ListFacts
         Fiat.Computation
         Fiat.Computation.Refinements.Iterate_Decide_Comp

--- a/src/QueryStructure/Implementation/Operations/General/EmptyRefinements.v
+++ b/src/QueryStructure/Implementation/Operations/General/EmptyRefinements.v
@@ -1,5 +1,5 @@
 Require Import Coq.Strings.String
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Lists.List
         Coq.Logic.FunctionalExtensionality
         Coq.Sets.Ensembles

--- a/src/QueryStructure/Implementation/Operations/General/InsertRefinements.v
+++ b/src/QueryStructure/Implementation/Operations/General/InsertRefinements.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String Coq.omega.Omega Coq.Lists.List
+Require Import Coq.Strings.String Coq.ZArith.ZArith Coq.Lists.List
         Coq.Logic.FunctionalExtensionality Coq.Sets.Ensembles
         Fiat.Computation
         Fiat.Computation.Refinements.Iterate_Decide_Comp

--- a/src/QueryStructure/Implementation/Operations/General/MutateRefinements.v
+++ b/src/QueryStructure/Implementation/Operations/General/MutateRefinements.v
@@ -1,5 +1,5 @@
 Require Import Coq.Strings.String
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Lists.List
         Coq.Logic.FunctionalExtensionality
         Coq.Sets.Ensembles

--- a/src/QueryStructure/Implementation/Operations/General/QueryRefinements.v
+++ b/src/QueryStructure/Implementation/Operations/General/QueryRefinements.v
@@ -1,6 +1,6 @@
 Require Import
         Coq.Arith.Arith
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.NArith.NArith
         Coq.ZArith.ZArith
         Coq.Strings.String

--- a/src/QueryStructure/Implementation/Operations/General/QueryStructureRefinements.v
+++ b/src/QueryStructure/Implementation/Operations/General/QueryStructureRefinements.v
@@ -1,5 +1,5 @@
 Require Import Coq.Strings.String
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Lists.List
         Coq.Logic.FunctionalExtensionality
         Coq.Sets.Ensembles

--- a/src/QueryStructure/Implementation/Operations/List/ListInsertRefinements.v
+++ b/src/QueryStructure/Implementation/Operations/List/ListInsertRefinements.v
@@ -1,5 +1,5 @@
 Require Import Coq.Strings.String
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Lists.List
         Coq.Logic.FunctionalExtensionality
         Coq.Sets.Ensembles

--- a/src/QueryStructure/Implementation/Operations/List/ListQueryRefinements.v
+++ b/src/QueryStructure/Implementation/Operations/List/ListQueryRefinements.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String Coq.omega.Omega Coq.Lists.List
+Require Import Coq.Strings.String Coq.ZArith.ZArith Coq.Lists.List
         Coq.Logic.FunctionalExtensionality Coq.Sets.Ensembles
         Coq.Sorting.Permutation
         Fiat.Computation

--- a/src/QueryStructure/Specification/Representation/QueryStructureNotations.v
+++ b/src/QueryStructure/Specification/Representation/QueryStructureNotations.v
@@ -1,5 +1,5 @@
 Require Export Coq.Strings.String
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Coq.Lists.List
         Coq.Logic.FunctionalExtensionality
         Coq.Sets.Ensembles

--- a/src/QueryStructure/Specification/Representation/TupleADT.v
+++ b/src/QueryStructure/Specification/Representation/TupleADT.v
@@ -1,7 +1,7 @@
 Require Import Coq.Lists.List
         Coq.Strings.String
         Coq.Arith.Arith
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Fiat.Common.ilist2
         Fiat.Common.StringBound
         Fiat.ADT

--- a/src/QueryStructure/Specification/Representation/TupleADT2.v
+++ b/src/QueryStructure/Specification/Representation/TupleADT2.v
@@ -1,7 +1,7 @@
 Require Import Coq.Lists.List
         Coq.Strings.String
         Coq.Arith.Arith
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Fiat.Common.ilist2
         Fiat.Common.StringBound
         Fiat.ADT

--- a/src/QueryStructure/Specification/SearchTerms/InRange.v
+++ b/src/QueryStructure/Specification/SearchTerms/InRange.v
@@ -1,5 +1,5 @@
 Require Import Coq.Arith.Compare_dec
-        Coq.omega.Omega
+        Coq.ZArith.ZArith
         Fiat.QueryStructure.Specification.Representation.QueryStructureNotations.
 
 Section RangeClause.


### PR DESCRIPTION
Compatiblity with coq/coq#13741

Since we still use the compat files, hopefully we'll automatically pick
up the replacement `omega` tactic.  Since `ZArith` exports `Omega`, this
should remove errors.