### PR TITLE
Speed up morphism search of setoid-rewrite

### DIFF
--- a/src/Common.v
+++ b/src/Common.v
@@ -288,7 +288,18 @@ Ltac setoid_rewrite_hyp := repeat setoid_rewrite_hyp'.
 Ltac setoid_rewrite_rev_hyp' := do_with_hyp ltac:(fun H => setoid_rewrite <- H).
 Ltac setoid_rewrite_rev_hyp := repeat setoid_rewrite_rev_hyp'.
 
-Hint Extern 0 => solve [apply reflexivity] : typeclass_instances.
+Ltac apply_reflexivity := lazymatch goal with
+| |- ?R ?x ?y => tryif is_evar R then fail else
+  (* Avoid a bad interaction with `Proper` proof search *)
+  lazymatch R with
+  | @Normalizes _ => fail
+  | @subrelation _ => fail
+  | _ => solve [apply reflexivity]
+  end
+end.
+
+Hint Extern 0 => apply_reflexivity : typeclass_instances.
+
 Hint Extern 10 (Proper _ _) => progress cbv beta : typeclass_instances.
 
 Ltac set_evars :=

--- a/src/Common/List/ListMorphisms.v
+++ b/src/Common/List/ListMorphisms.v
@@ -219,6 +219,22 @@ Definition pointwise2_relation :=
   fun (A A': Type) {B : Type} (R : relation B) (f g : A -> A' -> B) =>
     forall a a', R (f a a') (g a a').
 
+Instance pointwise2_subrelation {A A' B} (R : relation B) :
+  subrelation (pointwise2_relation A A' R) (pointwise_relation A (pointwise_relation A' R)).
+Proof. intros x y r. apply r. Qed.
+
+Instance pointwise2_subrelation_inv {A A' B} (R : relation B) :
+  subrelation (pointwise_relation A (pointwise_relation A' R)) (pointwise2_relation A A' R).
+Proof. intros x y r. apply r. Qed.
+
+Instance pointwise2_forall_relation {A A' B} (R : relation B) :
+  subrelation (pointwise2_relation A A' R) (forall_relation (fun _ : A => forall_relation (fun _ : A' => R))).
+Proof. intros x y r. apply r. Qed.
+
+Instance pointwise2_forall_relation_inv {A A' B} (R : relation B) :
+  subrelation (forall_relation (fun _ : A => forall_relation (fun _ : A' => R))) (pointwise2_relation A A' R).
+Proof. intros x y r. apply r. Qed.
+
 Add Parametric Morphism {A B: Type} :
   (@List.fold_right A B)
     with signature (@pointwise2_relation B A _ eq ==> eq ==> eq ==> eq)

--- a/src/Common/SetoidInstances.v
+++ b/src/Common/SetoidInstances.v
@@ -21,12 +21,15 @@ Instance proper_const {A B} {R1 : relation A} {R2}
 Proof.
   repeat intro; reflexivity.
 Qed.
-Instance pointwise_Proper {A B} R (f : A -> B) `{forall x, Proper R (f x)}
+
+Lemma pointwise_Proper {A B} R (f : A -> B) `{forall x, Proper R (f x)}
 : Proper (pointwise_relation A R) f.
 Proof.
   unfold Proper in *.
   repeat intro; trivial.
 Qed.
+
+Hint Extern 10 (Proper (pointwise_relation _ _) _) => class_apply @pointwise_Proper : typeclass_instances.
 
 Global Instance sumbool_rect_Proper {L R : Prop} {P} {R1}
 : Proper (pointwise_relation L R1 ==> pointwise_relation R R1 ==> @forall_relation _ (fun _ : {L} + {R} => P) (fun _ => R1))

--- a/src/Computation/SetoidMorphisms.v
+++ b/src/Computation/SetoidMorphisms.v
@@ -127,6 +127,13 @@ Proof.
   destruct c; eauto.
 Qed.
 
+Instance subrelation_refine {A} : subrelation (pointwise_relation A impl) (flip refine) := fun x y R => R.
+Instance subrelation_refine_impl {A} : subrelation (pointwise_relation A (flip impl)) refine := fun x y R => R.
+Instance subrelation_refine_equiv_flip_impl {A} : subrelation refineEquiv (pointwise_relation A (flip impl)).
+Proof. intros x y [H H0]. apply H. Qed.
+Instance subrelation_refine_equiv_impl {A} : subrelation refineEquiv (pointwise_relation A impl).
+Proof. intros x y [H H0]. apply H0. Qed.
+
 Add Parametric Morphism A
 : (@Pick A)
     with signature

--- a/src/Parsers/ContextFreeGrammar/Fix/Fix.v
+++ b/src/Parsers/ContextFreeGrammar/Fix/Fix.v
@@ -16,6 +16,13 @@ Require Import Fiat.Common.SetoidInstances. (* must come after the above for ins
 Set Implicit Arguments.
 Local Open Scope grammar_fixedpoint_scope.
 
+Instance: Params (@PositiveMapExtensions.defaulted_f) 5 := {}.
+Instance: Params (@PositiveMap.find) 1 := {}.
+Instance: Params (@PositiveMap.mapi) 2 := {}.
+Instance: Params (option_rect_nodep) 4 := {}.
+Instance: Params (@least_upper_bound) 2 := {}.
+Instance: Params (@eq) 1 := {}.
+
 Section grammar_fixedpoint.
   Context {Char : Type}.
 
@@ -157,6 +164,9 @@ Section grammar_fixedpoint.
 
   Definition aggregate_state_lub_f : option (state gdata) -> option (state gdata) -> option (state gdata)
       := PositiveMapExtensions.defaulted_f default_value default_value least_upper_bound.
+
+  (** Do not search for Proper instances for partial applications of this constant. *)
+  Instance: Params (@aggregate_state_lub_f) 0 := {}.
 
   Definition aggregate_state_lub (v1 v2 : aggregate_state) : aggregate_state
     := PositiveMap.map2 aggregate_state_lub_f v1 v2.

--- a/src/Parsers/ContextFreeGrammar/Fix/FromAbstractInterpretation.v
+++ b/src/Parsers/ContextFreeGrammar/Fix/FromAbstractInterpretation.v
@@ -58,6 +58,12 @@ Section fold_correctness.
           er_correct := ex_intro _ n (conj (er_correct it) (er_correct its));
           er_state_le := combine_production_Proper_le (er_state_le it) (er_state_le its) |}.
 
+  Instance flip_state_le_eta : subrelation (flip (C:=Prop) (fun x y => x <= y)) (fun x y : state => flip state_le x y).
+  Proof. firstorder. Qed.
+
+  Instance flip_state_le_eta_inv : subrelation (flip state_le) (fun x y : state => flip (C:=Prop) state_le x y).
+  Proof. firstorder. Qed.
+
   Lemma fold_le nt st
         (H : st <= fold_productions' (lookup_state fold_grammar) (opt.compile_productions (Lookup_string G nt)))
     : st <= lookup_state fold_grammar (of_nonterminal nt).


### PR DESCRIPTION
This is another patch that greatly speeds up setoid_rewrite (removing some of the existing logic to handle pointwise relations, that are now better done by the Coq PR). Hopefully it is also backwards compatible, otherwise, I'll make an overlay for coq/coq#13969